### PR TITLE
Added cisco object-group support.  fixes #36

### DIFF
--- a/aclgen.py
+++ b/aclgen.py
@@ -117,14 +117,15 @@ def revision_tag_handler(fname, text):
   return '\n'.join(new_text)
 
 
-def get_policy_obj(source_file, definitions_obj, optimize, shade_check):
+def get_policy_obj(source_file, definitions_obj, optimize, shade_check,
+                  platform=None):
   """Memoized call to parse policy by file name.
 
   Returns parsed policy object.
   """
 
   return policy.CacheParseFile(source_file, definitions_obj, optimize,
-                               shade_check=shade_check)
+                               shade_check=shade_check, platform=platform)
 
 
 def render_filters(source_file, definitions_obj, shade_check, exp_info):
@@ -173,7 +174,8 @@ def render_filters(source_file, definitions_obj, shade_check, exp_info):
       optimized = this_platform['optimized']
       # Copy Policy Obj.
       pol = copy.deepcopy(get_policy_obj(source_file, definitions_obj,
-                                         optimized, shade_check))
+                                         optimized, shade_check,
+                                         target_platform))
       renderer = this_platform['renderer']
       # Render.
       fw = renderer(pol, exp_info)


### PR DESCRIPTION
Also, cleans up Cisco header comment sequence and placements when using multiple headers for the same target.

Also, switched to using protocol names instead of protocol integers, I am not sure if that is unsupported on some Cisco's (may need to revert this part if so), but our Cisco devices convert the protocol integer to protocol name which makes post verification painful as the version produced by the device is translated and the version produced by Capirca is (was) integer, raising false errors on our post process validation.

Note, we need to get some tests written and shipped with this package.