### PR TITLE
Add .gitignore for generated filter/sample files and .pyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+venv/
 
 # Generated files
 filters/sample_*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *.pyc
 venv/
 
+# build output from 'python setup.py install'
+build/
+
 # Generated files
 filters/sample_*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+
+# Generated files
+filters/sample_*

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 
 # Generated files
 filters/sample_*
+def/AUTOGEN.net


### PR DESCRIPTION
I checked out caprica locally, and following the [Quick-start] (https://github.com/google/capirca/wiki/Quick-start) guide I generated the filters with `./aclgen.py`.  This added a number of untracked files to the repo:

```
	filters/sample_cisco_lab.acl
	filters/sample_gce.gce
	filters/sample_ipset
	... etc ...
	... a number of .pyc files ...
```

This PR hides those to keep the working directory clean.

If this isn't the preferred way of dealing with this (i.e., if you would prefer that developers have their own personal .gitignore file), I can submit a separate PR with instructions to the README or wherever is appropriate.