### PR TITLE
Add pyyaml, required for definate.py.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# Dependencies
+# Usage:
+#   $ pip install -r requirements.txt
+
+PyYAML==3.11


### PR DESCRIPTION
On a fresh install (or using virtualenv), `definate.py` currently fails:

```
$ ./definate.py 
Traceback (most recent call last):
  File "./definate.py", line 29, in <module>
    import yaml
ImportError: No module named yaml
```

This is fixed with `sudo pip install PyYAML`.  I've added a `requirements.txt` so users can install the needed dependencies with `$ pip install -r requirements.txt`.

I tried to add pyyaml to setup.py, but got a warning:  `/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'install_requires'`.  I didn't want to change setup.py further (i.e., change from distutils.core to setuptools), as that seemed invasive.
