### PR TITLE
Add aclgen smoketests

### DIFF
--- a/aclgen.py
+++ b/aclgen.py
@@ -28,6 +28,7 @@ import datetime
 from optparse import OptionParser
 import os
 import logging
+import sys
 
 # compiler imports
 from lib import naming
@@ -50,27 +51,30 @@ from lib import packetfilter
 from lib import demo
 from lib import nsxv
 
-
 # pylint: disable=bad-indentation
-_parser = OptionParser()
-_parser.add_option('-d', '--def', dest='definitions',
-                   help='definitions directory', default='./def')
-_parser.add_option('-o', dest='output_directory', help='output directory',
-                   default='./filters')
-_parser.add_option('', '--poldir', dest='policy_directory',
-                   help='policy directory (incompatible with -p)',
-                   default='./policies')
-_parser.add_option('-p', '--pol',
-                   help='policy file (incompatible with poldir)',
-                   dest='policy')
-_parser.add_option('--debug', help='enable debug-level logging', dest='debug')
-_parser.add_option('-s', '--shade_checking', help='Enable shade checking',
-                   action="store_true", dest="shade_check", default=False)
-_parser.add_option('-e', '--exp_info', type='int', action='store',
-                   dest='exp_info', default=2,
-                   help='Weeks in advance to notify that a term will expire')
 
-(FLAGS, args) = _parser.parse_args()
+def parse_args(command_line_args):
+  """Populate flags from the command-line arguments."""
+  _parser = OptionParser()
+  _parser.add_option('-d', '--def', dest='definitions',
+                     help='definitions directory', default='./def')
+  _parser.add_option('-o', dest='output_directory', help='output directory',
+                     default='./filters')
+  _parser.add_option('', '--poldir', dest='policy_directory',
+                     help='policy directory (incompatible with -p)',
+                   default='./policies')
+  _parser.add_option('-p', '--pol',
+                     help='policy file (incompatible with poldir)',
+                     dest='policy')
+  _parser.add_option('--debug', help='enable debug-level logging', dest='debug')
+  _parser.add_option('-s', '--shade_checking', help='Enable shade checking',
+                     action="store_true", dest="shade_check", default=False)
+  _parser.add_option('-e', '--exp_info', type='int', action='store',
+                     dest='exp_info', default=2,
+                     help='Weeks in advance to notify that a term will expire')
+
+  flags, unused_args = _parser.parse_args(command_line_args)
+  return flags
 
 
 def load_and_render(base_dir, defs, shade_check, exp_info, output_dir):
@@ -185,7 +189,9 @@ def render_filters(source_file, definitions_obj, shade_check, exp_info, output_d
   return count
 
 
-def main():
+def main(args):
+  FLAGS = parse_args(args)
+
   # Do some sanity checking.
   if FLAGS.policy_directory and FLAGS.policy:
     # When parsing a single file, ignore default path of policy_directory.
@@ -219,4 +225,7 @@ def main():
 if __name__ == '__main__':
 
   # Start main program.
-  main()
+  # Pass in command-line args (except for first entry, which is the script name).
+  # Note that OptionParser slices sys.argv in this way as well,
+  # ref https://docs.python.org/2/library/optparse.html.
+  main(sys.argv[1:])

--- a/aclgen.py
+++ b/aclgen.py
@@ -186,6 +186,17 @@ def render_filters(source_file, definitions_obj, shade_check, exp_info):
 
 
 def main():
+  # Do some sanity checking.
+  if FLAGS.policy_directory and FLAGS.policy:
+    # When parsing a single file, ignore default path of policy_directory.
+    FLAGS.policy_directory = False
+  if not (FLAGS.policy_directory or FLAGS.policy):
+    raise ValueError('must provide policy or policy_directive')
+
+  # Set log level to DEBUG if debug option is specified.
+  if FLAGS.debug:
+    logging.basicConfig(level=logging.DEBUG)
+
   if not FLAGS.definitions:
     _parser.error('no definitions supplied')
   defs = naming.Naming(FLAGS.definitions)
@@ -206,16 +217,6 @@ def main():
 
 
 if __name__ == '__main__':
-  # Do some sanity checking.
-  if FLAGS.policy_directory and FLAGS.policy:
-    # When parsing a single file, ignore default path of policy_directory.
-    FLAGS.policy_directory = False
-  if not (FLAGS.policy_directory or FLAGS.policy):
-    raise ValueError('must provide policy or policy_directive')
-
-  # Set log level to DEBUG if debug option is specified.
-  if FLAGS.debug:
-    logging.basicConfig(level=logging.DEBUG)
 
   # Start main program.
   main()

--- a/aclgen.py
+++ b/aclgen.py
@@ -73,22 +73,22 @@ _parser.add_option('-e', '--exp_info', type='int', action='store',
 (FLAGS, args) = _parser.parse_args()
 
 
-def load_and_render(base_dir, defs, shade_check, exp_info):
+def load_and_render(base_dir, defs, shade_check, exp_info, output_dir):
   rendered = 0
   for dirfile in dircache.listdir(base_dir):
     fname = os.path.join(base_dir, dirfile)
     #logging.debug('load_and_render working with fname %s', fname)
     if os.path.isdir(fname):
-      rendered += load_and_render(fname, defs, shade_check, exp_info)
+      rendered += load_and_render(fname, defs, shade_check, exp_info, output_dir)
     elif fname.endswith('.pol'):
       #logging.debug('attempting to render_filters on fname %s', fname)
-      rendered += render_filters(fname, defs, shade_check, exp_info)
+      rendered += render_filters(fname, defs, shade_check, exp_info, output_dir)
   return rendered
 
 
-def filter_name(source, suffix):
+def filter_name(source, suffix, output_directory):
   source = source.lstrip('./')
-  o_dir = '/'.join([FLAGS.output_directory] + source.split('/')[1:-1])
+  o_dir = '/'.join([output_directory] + source.split('/')[1:-1])
   fname = '%s%s' % (".".join(os.path.basename(source).split('.')[0:-1]),
                     suffix)
   return os.path.join(o_dir, fname)
@@ -127,7 +127,7 @@ def get_policy_obj(source_file, definitions_obj, optimize, shade_check):
                                shade_check=shade_check)
 
 
-def render_filters(source_file, definitions_obj, shade_check, exp_info):
+def render_filters(source_file, definitions_obj, shade_check, exp_info, output_dir):
   """Render platform specfic filters for each target platform.
 
   For each target specified in each header of the policy, use that
@@ -178,7 +178,7 @@ def render_filters(source_file, definitions_obj, shade_check, exp_info):
       # Render.
       fw = renderer(pol, exp_info)
       # Output.
-      do_output_filter(str(fw), filter_name(source_file, fw._SUFFIX))
+      do_output_filter(str(fw), filter_name(source_file, fw._SUFFIX, output_dir))
       # Count.
       count += 1
 
@@ -207,11 +207,11 @@ def main():
   count = 0
   if FLAGS.policy_directory:
     count = load_and_render(FLAGS.policy_directory, defs, FLAGS.shade_check,
-                            FLAGS.exp_info)
+                            FLAGS.exp_info, FLAGS.output_directory)
 
   elif FLAGS.policy:
     count = render_filters(FLAGS.policy, defs, FLAGS.shade_check,
-                           FLAGS.exp_info)
+                           FLAGS.exp_info, FLAGS.output_directory)
 
   print '%d filters rendered' % count
 

--- a/test/test_aclgen.py
+++ b/test/test_aclgen.py
@@ -1,0 +1,67 @@
+import unittest
+import sys
+import os
+from cStringIO import StringIO
+
+import aclgen
+
+class Test_AclGen(unittest.TestCase):
+
+  def setUp(self):
+    # Capture output during tests.
+    self.iobuff = StringIO()
+    sys.stderr = sys.stdout = self.iobuff
+
+  def tearDown(self):
+    sys.stdout = sys.__stdout__
+    sys.stderr = sys.__stderr__
+
+  def test_smoke_test_generates_successfully_with_no_args(self):
+    aclgen.main([])
+
+    expected_output = """writing ./filters/sample_cisco_lab.acl
+writing ./filters/sample_gce.gce
+writing ./filters/sample_ipset
+WARNING:root:WARNING: Term accept-traceroute in policy LOOPBACK is expired and will not be rendered.
+writing ./filters/sample_juniper_loopback.jcl
+writing ./filters/sample_multitarget.jcl
+writing ./filters/sample_multitarget.acl
+writing ./filters/sample_multitarget.ipt
+writing ./filters/sample_multitarget.asa
+writing ./filters/sample_multitarget.demo
+writing ./filters/sample_multitarget.eacl
+writing ./filters/sample_multitarget.bacl
+writing ./filters/sample_multitarget.xacl
+writing ./filters/sample_multitarget.jcl
+writing ./filters/sample_multitarget.acl
+writing ./filters/sample_multitarget.ipt
+writing ./filters/sample_multitarget.asa
+WARNING:root:WARNING: Term accept-traceroute in policy inet is expired and will not be rendered.
+WARNING:root:WARNING: Action ['next'] in Term ratelimit-large-dns is not valid and will not be rendered.
+writing ./filters/sample_nsxv.nsx
+writing ./filters/sample_packetfilter.pf
+writing ./filters/sample_speedway.ipt
+writing ./filters/sample_speedway.ipt
+writing ./filters/sample_speedway.ipt
+writing ./filters/sample_srx.srx
+22 filters rendered
+"""
+
+    self.assertEquals(expected_output, self.iobuff.getvalue())
+
+  def test_generate_single_policy(self):
+    aclgen.main(['-p', 'policies/sample_cisco_lab.pol'])
+
+    expected_output = """writing ./filters/sample_cisco_lab.acl
+1 filters rendered
+"""
+    self.assertEquals(expected_output, self.iobuff.getvalue())
+
+
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
This is a preparatory PR that should let us add characterization tests to the existing code.  It adds some simple smoke tests to `aclgen.py`, generating to the existing project folders.  The output is _not_ checked, these are smoke tests only.

The tests can be run from the project root dir with `$ python -m unittest discover`.

If/when this PR is accepted, I can add some very simple characterization tests, which would consist of running acl with the existing committed data, storing the output, and using that as the basis for test assertions, which would allow for work on the code without breaking anything.

**Summary of code changes:**

* `main()` parameterized to `main(array_of_args)` so unit tests can pass in different arg lists.
* Added `test` folder to keep this distinct from `tests` folder.  I don't know if the existing `tests` actually work, and didn't want to expand the scope of this PR.
* passing the FLAGS.output_directory explicitly to routings that need it, rather than using a global FLAGS variable.  FLAGS could have been left as global, but for the tests to work it would need to be marked as 'global' in a few places which felt ugly.  I can undo that change if preferred.

**Notes:**

* `test/test_aclgen.py` captures the stdout/sterr output of the test runs.  This assumes that the folder only contain information which has been committed as part of the base project.  If people are making independent changes _in this source code_, it's going to be hard to track.  Another option would be to add an array of items that we think should be checked (that is, the "official" source code).
* I haven't added anything to the README about how to run the tests (`$ python -m unittest discover`), but can do so
