### PR TITLE
Add linter for policies and network/service defs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 *.pyc
 venv/
+.arcconfig
 
 # build output from 'python setup.py install'
 build/
 
 # Generated files
 filters/sample_*
+policies/sample_*
 def/AUTOGEN.net

--- a/README.md
+++ b/README.md
@@ -1,3 +1,169 @@
 #Capirca
 
 Capirca is a tool designed to utilize common definitions of networks, services and high-level policy files to facilitate the development and manipulation of network access control lists (ACLs) for various platforms. It was developed by Google for internal use, and is now open source.
+
+
+#Lint
+
+Lint is a mechanism to analyze policies, network definitions, and service definitions to meet style criteria. The intention is for this tooling to be used as part of the policy development process to ensure consistency and make change-review easier. Lint rules can be enabled, disabled, and configured via a command-line specified YAML file. It is suggested to integrate the lint tooling into your software development code review tool to maximize the benefits.
+
+##Running Lint
+
+The linting comes in two different scripts - one for naming files (.net, .svc), and one for policy files. When linting a policy file, the naming definitions directory must be provided for the policies due to the way that the lint engine works.
+
+Running the linters is quite simple:
+
+```
+$ ./namelint.py def/NETWORK.net
+def/NETWORK.net -
+  4 <Warning> 10.0.0.0/8 #  non-public indented by 10, not 4
+  5 <Warning> 172.16.0.0/12 #  non-public indented by 10, not 4
+...
+$
+
+$ ./pollint.py -d def policies/includes/untrusted-networks-blocking.inc
+$
+```
+
+You can additionally specify a yaml configuration file - which will map to the configured parameters in the lint class:
+```
+$ cat example_lint.yaml
+IndentEnforcer:
+  enabled: false
+
+RegexNameEnforcer:
+    NETNAME: ".*"
+
+$ ./namelint.py -c policies/lint/example_lint.yaml def/NETWORK.net
+def/NETWORK.net -
+  64 <Warning> 3ffe::/16 is an extremely large network, with more than 9 quintillion addresses
+  65 <Warning> 5f00::/8 is an extremely large network, with more than 9 quintillion addresses
+  66 <Warning> 2001:db8::/32 is an extremely large network, with more than 9 quintillion addresses
+```
+
+It is suggested that any environment-specific settings be changed via the YAML file, rather than changing the core code itself.
+
+##Linter Style Guide
+
+The provided defaults for the lint engine use the following style guide - it is by no means good for all use cases, but can be a good basis for bootstrapping your own style choices.
+
+###Terms
+
+* Term names should be all lower case and use dashes (-) to separate words
+* Term names for IPv6 only rules should be appended with "-v6"
+* Term names should be concise yet accurate and informative wherever possible; someone with no prior context should be able to get a general feeling for use the term serves upon reading its name and description. Use the "comment" field to elaborate if needed, but keep the term name useful
+* Term names must be 31 or fewer total characters (limitation of some platforms)
+* Term names generally **should not** have "allow-" or "permit-" in the name, it is understood that the term is being put in to allow something. Conversely, since terms denying traffic are rare, they **should** have "deny-" in the name.
+* Terms in boilerplates (.inc files) should always start with the prefix "bp-"
+
+**YES** - follow this!
+```
+term www-frontend {
+    comment:: "#1234567 allow inbound Internet access to frontend clusters"
+    <other fields omitted>
+}
+
+# In a boilerplate (.inc file), terms are prefixed by "bp-" to differentiate imported (.inc) terms versus .pol terms in the generated config
+term bp-dns-return {
+    comment:: "Allowing DNS return traffic for X VLAN"
+    <other fields omitted>
+}
+```
+
+**NO** - do not do this!
+```
+term WEB {
+    <other fields omitted>
+}
+
+term permit_web {
+    comment:: "HTTPS"
+    <other fields omitted>
+}
+
+term allow-www-frontend {
+    comment:: "WEB TRAFFIC"
+    <other fields omitted>
+}
+```
+
+###Network Name Definitions
+
+* All UPPER case with UNDERSCORE (_) to separate words
+* Single-address entries can be all on 1 line or broken out into 2 lines
+* Multiple IPs & prefix lists: 1 per line, indented 4 spaces
+* IPv6 only objects MUST be suffixed with _V6, and mixed objects MUST be suffixed by _ALL
+* IPv4 only objects MUST NOT be suffixed with _V4
+* Must begin with letter
+* Avoid nesting network objects within other network objects where possible
+
+**YES** - follow this!
+```
+# this is my main jumphost
+JUMPHOST = 172.16.0.1/32
+
+# these are all my jumphosts
+ALL_JUMPHOSTS =
+    172.16.0.1/32
+    192.168.0.1/32
+    10.0.0.1/32
+
+# these are reserved networks
+RFC_1918_AGGS =
+    10.0.0.0/8    # I like this one
+    192.168.0.0/16    # I never liked this network
+    172.16.0.0/12    # I don't even know why we ever used this
+```
+
+**NO** - do not do this!
+```
+# avoid lower-case object names and use 4-space indents for the addresses
+rfc-1918-aggs =
+10.0.0.0/8
+192.168.0.0/16
+172.16.0.0/12
+
+# avoid nesting single-address objects inside other objects when it's easily avoidable and don't start a group name with a number
+1918_AGGS =
+    net_10.0.0.0_8 # it's better to just use 10.0.0.0/8 here
+    net_192.168.0.0_16
+    net_172.16.0.0_12
+```
+
+###Service Name Definitions
+
+* In general, do not mix tcp and udp in the same service group UNLESS the port numbers are shared across both protocols
+* Use underscores (_) to separate words if needed
+* Single ports and port ranges should begin with TCP or UDP
+* Groups with multiple ports should be named in accordance with its function (eg, SNMP)
+* Groups must have 1 port or range per line, indented 4 spaces
+* Must begin with letter
+* Syntax:
+** PROTOCOL_PORT = PORT/protocol
+** PROTOCOL_PORT1-PORT2 = PORT1-PORT2/protocol
+
+**YES** - do this!
+```
+TCP_3074 = 3074/tcp
+TCP_22 = 22/tcp
+UDP_1-65535 = 1-65535/udp
+SNMP =
+    161/udp
+    161/tcp
+```
+
+**NO** - please do not do this!
+```
+tcp3074 = 3074/tcp
+tcp_3074 = 3074/tcp
+my_port = 3074/tcp
+databases_3306-3308 = 3306-3308/tcp
+AUTHENTICATION =
+  135/tcp
+  135/udp
+  137/udp
+  138/udp
+  139/tcp
+  139/udp
+  445/tcp
+```

--- a/lib/linters.py
+++ b/lib/linters.py
@@ -1,0 +1,612 @@
+# Copyright 2008 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from collections import namedtuple, defaultdict
+from copy import deepcopy
+import datetime
+import json
+import re
+import yaml
+from lib import nacaddr
+
+__author__ = 'mikeelkin2@fb.com (Mike Elkin)'
+
+Error = namedtuple('Error', ['filename', 'lineno', 'offset', 'severity',
+               'message', 'category'])
+
+
+def sanitizeNetworkItem(x):
+  # Remove comments and identify just the content we care about
+  return x.split('#', 1)[0].strip()
+
+
+class severity(object):
+  DISABLED = 'disabled'
+  ADVICE = 'advice'
+  WARNING = 'warning'
+  AUTOFIX = 'autofix'
+  ERROR = 'error'
+
+  @classmethod
+  def human(cls, k):
+    mapping = {
+      cls.DISABLED: 'Disabled',
+      cls.ADVICE: 'Advice',
+      cls.WARNING: 'Warning',
+      cls.ERROR: 'Error',
+      cls.AUTOFIX: 'Auto-Fix',
+    }
+    return mapping[k]
+
+  @classmethod
+  def int(cls, k):
+    mapping = {
+      cls.DISABLED: 10,
+      cls.ADVICE: 20,
+      cls.WARNING: 30,
+      cls.ERROR: 40,
+      cls.AUTOFIX: 25,
+    }
+    return mapping[k]
+
+
+class LintErrors(object):
+  def __init__(self):
+    self.errs = []
+    self.filename = None
+
+  def __iter__(self):
+    for e in self.errs:
+      yield e
+
+  def add(self, severity, msg, lineno=0, offset=0, filename=None,
+      category='CAP'):
+    fn = filename or self.filename or 'unknown'
+    self.errs.append(Error(fn, lineno, offset, severity, msg, category))
+
+  def tree(self, sort=True):
+    t = defaultdict(list)
+    for e in self.errs:
+      t[e.filename].append(e)
+    if sort:
+      for v in t.values():
+        v.sort(key=lambda e: e.lineno)
+    return t
+
+  def pprint(self):
+    for filename, errors in self.tree().iteritems():
+      print("%s -" % filename)
+      for error in errors:
+        print("  %5d <%s> %s" % (error.lineno,
+                     severity.human(error.severity),
+                     error.message))
+
+  def plain(self):
+    for error in sorted(self.errs, key=lambda x: (x.filename, x.lineno)):
+      print(error)
+
+  def json(self):
+    print(json.dumps(self.tree()))
+
+
+def register_linter(f):
+  """Class decorator to register a linter to be executed."""
+  globals().setdefault('CAPIRCA_LINTERS', []).append(f)
+  return f
+
+
+def get_linters():
+  return globals().get('CAPIRCA_LINTERS', [])
+
+
+def build_linters(configpath):
+  errors = LintErrors()
+  if configpath:
+    with open(configpath) as f:
+      config = yaml.load(f.read())
+  else:
+    config = {}
+  linters = [kls(errors=errors, config=config) for kls in get_linters()]
+  return (errors, linters)
+
+
+class BaseLintRule(object):
+
+  """Base Lint Rule class. All lint rules should extend this.
+
+  All configurable parameters should be placed into DEFAULTS - as these
+  values get merged with the optional user-specified YAML file.
+  """
+
+  CONFIG_NAME = None
+  DEFAULT_ENABLED = True
+  CATEGORY = None
+  DEFAULTS = {}
+
+  def __init__(self, errors, config):
+    self.global_config = config
+    self.errors = errors
+    # build a local copy of the linter specific config
+    cn = self.CONFIG_NAME or self.__class__.__name__
+    local_config = deepcopy(self.DEFAULTS)
+    local_config.update(self.global_config.get(cn, {}))
+    self.config = local_config
+    self.setup()
+
+  def setup(self):
+    """setup() may optionally be implemented by each linter"""
+    pass
+
+  def add(self, *args, **kwargs):
+    if 'category' not in kwargs and self.CATEGORY:
+      kwargs['category'] = self.CATEGORY
+    self.errors.add(*args, **kwargs)
+
+  def lint_naming(self, definitions):
+    """Execute the lint check_* methods against the specified definitions."""
+    if not self.config.get('enabled', self.DEFAULT_ENABLED):
+      return
+
+    for itemunit in definitions.networks.values():
+      self.check_network(itemunit)
+
+    for itemunit in definitions.services.values():
+      self.check_service(itemunit)
+
+    self.check_networks(definitions.networks)
+    self.check_services(definitions.services)
+
+  def lint_policy(self, policy):
+    """Execute the lint check_term method against the specified policy"""
+    if not self.config.get('enabled', self.DEFAULT_ENABLED):
+      return
+
+    for header, terms in policy.filters:
+      if not terms:
+        # no terms included -probably just include statements
+        continue
+      for term in terms:
+        self.check_term(policy.filename, header, term)
+
+  def check_network(self, network):
+    """May be implemented to check a given network found in a .net file"""
+    pass
+
+  def check_service(self, service):
+    """May be implemented to check a given service found in a .svc file"""
+    pass
+
+  def check_networks(self, networks):
+    """May be implemented to check all of the networks found in a .net file"""
+    pass
+
+  def check_services(self, services):
+    """May be implemented to check all of the services found in a .svc file"""
+    pass
+
+  def check_term(self, policy, header, term):
+    """May be implemented to check the given term under a given header"""
+    pass
+
+
+@register_linter
+class AddressNumEnforce(BaseLintRule):
+
+  """ Warns about terms with more than a few address tokens. """
+
+  def check_term(self, policy, header, term):
+    addr_attrs = (
+      'source_address',
+      'destination_address',
+      'destination_address_exclude',
+      'source_address_exclude',
+    )
+    for attrname in addr_attrs:
+      addrs = getattr(term, attrname)
+      parents = set([addr.parent_token for addr in addrs])
+      if len(parents) > 4:
+        msg = ("term %s has too many objects in" % term.name +
+             " one of the address fields. " +
+             "Please review and consolidate the addresses")
+        self.add(severity.WARNING, msg, term.name.lineno)
+
+
+@register_linter
+class RegexNameEnforcer(BaseLintRule):
+
+  """ Ensures objects and terms following naming conventions. """
+
+  DEFAULTS = {
+    'NETNAME': r'^([A-Z][A-Z0-9_]+|h_[0-9a-f\.]+|n_[0-9a-f\.]+_[0-9]+)$',
+    'SVCNAME': r'^((TCP|UDP|TCP_UDP)_[0-9]+(-[0-9]+)?|[A-Z][A-Z0-9_]+)$',
+    'TERMNAME': {
+      'default': r'^[a-z][a-z0-9\-\.]+$',
+      'srx': r'^[a-z][a-z0-9\-]+$',
+    }
+  }
+
+  def setup(self):
+    self.netname_re = re.compile(self.config['NETNAME'])
+    self.svcname_re = re.compile(self.config['SVCNAME'])
+    self.termname_re = {k: re.compile(v) for k, v
+              in self.DEFAULTS['TERMNAME'].items()}
+
+  def check_network(self, network):
+    if not self.netname_re.match(network.name):
+      msg = '%s is not a valid network name' % network.name
+      self.add(severity.WARNING, msg, network.name.lineno)
+
+  def check_service(self, service):
+    if not self.svcname_re.match(service.name):
+      msg = '%s is not a valid service name' % service.name
+      self.add(severity.WARNING, msg, service.name.lineno)
+
+  def check_term(self, policy, header, term):
+    header_targets = {}
+    if header:
+      header_targets = {x.platform for x in header.target}
+    for target, re_pattern in self.termname_re.iteritems():
+      if target == 'default' and not re_pattern.match(term.name):
+        msg = ('%s is not a valid '
+             'term name for all platforms' % term.name)
+        self.add(severity.ERROR, msg, term.name.lineno)
+      elif target in header_targets and not re_pattern.match(term.name):
+        msg = '%s is not a valid term name for target: %s' % (term.name,
+                                    target)
+        self.add(severity.ERROR, msg, term.name.lineno)
+
+
+@register_linter
+class BoilerplateTermEnforcer(BaseLintRule):
+
+  """Enforces files with BOILERPLATE in the name must have all terms
+  prefixed with "bp-"
+  """
+
+  def check_term(self, policy, header, term):
+    if header:
+      return
+    if not term.name.startswith('bp-') and 'BOILERPLATE' in policy:
+      msg = ("Term %s is in a boilerplate, and should start with "
+           "'bp-'" % term.name)
+      self.add(severity.WARNING, msg, term.name.lineno)
+
+
+@register_linter
+class Inet6TermEnforcer(BaseLintRule):
+
+  """Enforces that if this is a file handling inet6, that all of the terms
+  must end with -v6."""
+
+  def check_term(self, policy, header, term):
+    if not header:
+      return
+    header_options = set()
+    for target in header.target:
+      header_options |= set(target.options)
+    if 'inet6' in header_options and not term.name.endswith('-v6'):
+      msg = ("Term %s is in an inet6 policy, and should end with "
+           "'-v6'" % term.name)
+      self.add(severity.WARNING, msg, term.name.lineno)
+
+
+@register_linter
+class SinglePortEnforcer(BaseLintRule):
+
+  """ Ensures service objects are defined according to the name. """
+
+  def check_service(self, service):
+    name = service.name
+    if name.startswith('TCP_UDP_'):
+      if len(service.items) == 2:
+        return
+      msg = '%s should contain two port specifications' % name
+      self.add(severity.WARNING, msg, name.lineno)
+    elif (name.startswith('TCP_') or name.startswith('UDP_')) \
+        and len(service.items) != 1:
+      msg = '%s should contain a single port specification' % name
+      self.add(severity.WARNING, msg, name.lineno)
+
+
+@register_linter
+class SameLineDefinitionsEnforcer(BaseLintRule):
+
+  """ Ensures the names of objects are not seen more than once. """
+
+  def check_service(self, service):
+    seen_lines = set()
+    for item in service.items:
+      if item.lineno in seen_lines:
+        msg = 'Services on same line'
+        self.add(severity.WARNING, msg, lineno=item.lineno)
+      seen_lines.add(item.lineno)
+
+  def check_network(self, network):
+    seen_lines = set()
+    for item in network.items:
+      if item.lineno in seen_lines:
+        msg = 'Networks on same line'
+        self.add(severity.WARNING, msg, lineno=item.lineno)
+      seen_lines.add(item.lineno)
+
+
+@register_linter
+class CharLengthEnforcer(BaseLintRule):
+
+  """ Ensures the names of objects or terms are under the maximum length. """
+
+  DEFAULTS = {
+    'MAX_TERM_LENS': {
+      'panfw': 31,
+      'juniper': 63,
+      'srx': 63,
+    },
+    'MAX_NETWORK_LEN': 63,
+    'MAX_SERVICE_LEN': 63,
+  }
+
+  def check_term(self, policy, header, term):
+    # For includes, which don't have a header, assume the lowest term
+    # length, as it could be included in a policy with any target
+    if not header:
+      max_len = min(self.config['MAX_TERM_LENS'].values())
+      if len(term.name) > max_len:
+        msg = ("Term %s is longer than %d characters" %
+             (term.name, max_len))
+        self.add(severity.WARNING, msg, lineno=term.name.lineno)
+    # for policy files, which have headers, only check for the appropriate
+    # target
+    else:
+      header_targets = {x.platform for x in header.target}
+      for target, max_len in self.config['MAX_TERM_LENS'].items():
+        if target in header_targets and len(term.name) > max_len:
+          msg = ("Term %s is longer than %d characters" %
+               (term.name, max_len))
+          self.add(severity.WARNING, msg, lineno=term.name.lineno)
+
+  def check_network(self, network):
+    max_len = self.config['MAX_NETWORK_LEN']
+    if len(network.name) > max_len:
+      msg = 'Network name %s is more than %d characters' % (network.name,
+                                  max_len)
+      self.add(severity.WARNING, msg, network.name.lineno)
+
+  def check_service(self, service):
+    max_len = self.config['MAX_SERVICE_LEN']
+    if len(service.name) > max_len:
+      msg = 'Service name %s is more than %d characters' % (service.name,
+                                  max_len)
+      self.add(severity.WARNING, msg, service.name.lineno)
+
+
+@register_linter
+class ExpiredTermEnforcer(BaseLintRule):
+
+  """ Notifies about terms that are expired or expiring soon. """
+
+  DEFAULTS = {
+    'WARN_DAYS': 14,
+    'ADVICE_DAYS': 30,
+    'ERROR_DAYS': 0,
+  }
+
+  def check_term(self, policy, header, term):
+    if term.expiration:
+      sev = None
+      days = (term.expiration - datetime.date.today()).days
+      if days < self.config['ERROR_DAYS']:
+        sev = severity.ERROR
+      elif days < self.config['WARN_DAYS']:
+        sev = severity.WARNING
+      elif days < self.config['ADVICE_DAYS']:
+        sev = severity.ADVICE
+      if sev is not None:
+        if days < 0:
+          msg = 'term is expired!'
+        else:
+          msg = '%d days until term expiration' % days
+        self.add(sev, msg, lineno=term.name.lineno)
+
+
+@register_linter
+class EmptyNetworkOrPorts(BaseLintRule):
+
+  """ Ensures network and service objects have an element within them. """
+
+  def check_service(self, service):
+    if not len(service.items):
+      msg = 'Services must contain at least one element'
+      self.add(severity.ERROR, msg, lineno=service.name.lineno)
+
+  def check_network(self, network):
+    if not len(network.items):
+      msg = 'Networks must contain at least one element'
+      self.add(severity.ERROR, msg, lineno=network.name.lineno)
+
+
+@register_linter
+class CheckValidNetwork(BaseLintRule):
+
+  """ Ensures network IP addresses are accurate and in the proper format,
+  and looks for eggregiously large IPv6 subnets."""
+
+  DEFAULTS = {
+    'IP_RE': r'[0-9a-f:\.]+(/[0-9]{1,3})?',
+    'CIDR_RE': r'(/[0-9]{1,3})',
+    'V6_WHITELIST': [
+      "::/8",
+      "100::/8",
+      "200::/7",
+      "400::/6",
+      "800::/5",
+      "1000::/4",
+      "4000::/3",
+      "6000::/3",
+      "8000::/3",
+      "a000::/3",
+      "c000::/3",
+      "e000::/4",
+      "f000::/5",
+      "f800::/6",
+      "fe00::/9",
+      "fec0::/10",
+    ],
+  }
+
+  def check_network(self, network):
+    regex = re.compile(self.config['IP_RE'])
+    cidr_regex = re.compile(self.config['CIDR_RE'])
+    for item in network.items:
+      stripped = sanitizeNetworkItem(item)
+      if not regex.match(stripped):
+        continue
+
+      try:
+        network = nacaddr.IP(stripped)
+      except ValueError:
+        msg = '%s is not a valid network' % stripped
+        self.add(severity.ERROR, msg, lineno=item.lineno)
+      else:
+        # ensure there the entry is in CIDR notation
+        if not cidr_regex.search(stripped):
+          msg = ('%s is not in CIDR notation (must have a /## '
+               "network assignment)") % stripped
+          self.add(severity.ERROR, msg, lineno=item.lineno)
+          # skip the other two checks because they require a network
+          continue
+        # Warn for extraordinarily large v6 subnets (usually a mistake
+        # from copying a v4 subnet)
+        if (network.prefixlen < 33 and network.version == 6 and
+            network.with_prefixlen.lower() not in
+            self.config['V6_WHITELIST']):
+          msg = ("%s is an extremely large network and may be an error. "
+                 "Please confirm this is the correct CIDR mask." %
+                 network.with_prefixlen)
+          self.add(severity.WARNING, msg, lineno=item.lineno)
+        # check that the IP they are defining is the network address
+        try:
+          # need the raw_ip without the subnet for comparing with the
+          # network address
+          raw_ip = str(nacaddr.IP(stripped.split("/")[0]).ip).lower()
+        except IndexError:
+          pass
+        else:
+          if raw_ip != str(network.network).lower():
+            msg = ("%s is not the network address for this "
+                 "network: %s/%s" % (raw_ip,
+                           str(network.network).lower(),
+                           network.prefixlen))
+            self.add(severity.ERROR, msg, lineno=item.lineno)
+
+
+@register_linter
+class NetworkMatcher(BaseLintRule):
+
+  """ Network name enforcement. Also ensures a given network name matches the
+    network specified. """
+
+  DEFAULTS = {
+    'NETNAME': r'^(h_[0-9a-f\.]+|n_[0-9a-f\.]+_[0-9]+)$',
+    'FUZZ_IPV6': True,
+  }
+
+  def check_network(self, network):
+    regex = re.compile(self.config['NETNAME'])
+    if not regex.match(network.name):
+      return
+    n = network.name.lstrip('hn_')
+    n = n.replace('_', '/')
+    if n.count('.') != 3:
+      # ipv6 address... we hope. fuzzit.
+      n = n.replace('.', ':')
+      if (n.find('::') < 0 and n.count(':') != 7 and
+          self.config['FUZZ_IPV6']):
+        # incomplete ipv6 - doubletap.
+        n = n + '::'
+    try:
+      net_ip = nacaddr.IP(n)
+    except ValueError:
+      msg = '%s (%s) is not a valid network' % (network.name, n)
+      self.add(severity.ERROR, msg, lineno=network.name.lineno)
+      return
+
+    for item in network.items:
+      sanitized = sanitizeNetworkItem(item)
+      try:
+        item_ip = nacaddr.IP(sanitized)
+      except ValueError:
+        # invalid network element - not our problem
+        continue
+      if net_ip != item_ip:
+        msg = ('%s does not match name specification of %s'
+             % (item_ip, net_ip))
+        self.add(severity.WARNING, msg, lineno=item.lineno)
+
+
+@register_linter
+class IndentEnforcer(BaseLintRule):
+
+  """ Ensures proper amount of indentation is present. """
+
+  DEFAULTS = {
+    'INDENT': 4,
+    'MIN_ELEMENTS': 2,
+  }
+
+  def check_network(self, network):
+    indent = self.config['INDENT']
+    if len(network.items) < self.config['MIN_ELEMENTS']:
+      return
+    for item in network.items:
+      if item.offset == indent:
+        continue
+      msg = '%s indented by %d, not %d' % (item, item.offset, indent)
+      self.add(severity.WARNING, msg, lineno=item.lineno)
+
+  def check_service(self, service):
+    indent = self.config['INDENT']
+    if len(service.items) < self.config['MIN_ELEMENTS']:
+      return
+    for item in service.items:
+      if item.offset == indent:
+        continue
+      msg = '%s indented by %d, not %d' % (item, item.offset, indent)
+      self.add(severity.WARNING, msg, lineno=item.lineno)
+
+
+@register_linter
+class CounterEnforcer(BaseLintRule):
+
+  """ Ensures terms in a policy with a given target have a counter """
+
+  DEFAULTS = {
+    'TARGETS': ['juniper'],
+  }
+
+  def check_term(self, policy, header, term):
+    # a header (with target(s) is required for this check, so skip it on
+    # include files
+    if not header:
+      return
+    header_targets = {x.platform for x in header.target}
+    for target in self.config['TARGETS']:
+      if target in header_targets and not term.counter:
+        msg = ('A counter is required for term %s, it\'s in a '
+               'policy with a "%s" target' % (term.name, target))
+        self.add(severity.WARNING, msg, lineno=term.name.lineno)

--- a/lib/policy.py
+++ b/lib/policy.py
@@ -30,7 +30,6 @@ from ply import yacc
 
 import logging
 
-
 DEFINITIONS = None
 DEFAULT_DEFINITIONS = './def'
 ACTIONS = set(('accept', 'deny', 'reject', 'next', 'reject-with-tcp-rst'))
@@ -167,6 +166,8 @@ class Policy(object):
   def _TranslateTerms(self, terms):
     """."""
     if not terms:
+      if globals().get('LINT_MODE'):
+        return
       raise NoTermsError('no terms found')
     for term in terms:
       # TODO(pmoody): this probably belongs in Term.SanityCheck(),
@@ -2151,7 +2152,7 @@ def ParseFile(filename, definitions=None, optimize=True, base_dir='',
 
 
 def ParsePolicy(data, definitions=None, optimize=True, base_dir='',
-                shade_check=False):
+                shade_check=False, track=False, filename=""):
   """Parse the policy in 'data', optionally provide a naming object.
 
   Parse a blob of policy text into a policy object.
@@ -2162,6 +2163,9 @@ def ParsePolicy(data, definitions=None, optimize=True, base_dir='',
     optimize: bool - whether to summarize networks and services.
     base_dir: base path string to look for acls or include files.
     shade_check: bool - whether to raise an exception when a term is shaded.
+    track: bool - whether or not to use original file content and track all
+                  locations of strings. useful for linting.
+    filename: the policy filename, foo.pol, etc.
 
   Returns:
     policy object or False (if parse error).
@@ -2178,10 +2182,30 @@ def ParsePolicy(data, definitions=None, optimize=True, base_dir='',
 
     lexer = lex.lex()
 
-    preprocessed_data = '\n'.join(_Preprocess(data, base_dir=base_dir))
+    def trackfn(*args, **kwargs):
+      """
+      Token handling wrapper to automatically track line numbers
+      for all strings
+      """
+      r = lexer.token(*args, **kwargs)
+      if not r:
+        # EOF is None
+        return
+      r.value = naming.TrackStr(r.value, lineno=r.lineno)
+      return r
+
+    if track:
+      tokenfunc = trackfn
+      globals()['LINT_MODE'] = True
+    else:
+      data = '\n'.join(_Preprocess(data, base_dir=base_dir))
+      tokenfunc = lexer.token
+
     p = yacc.yacc(write_tables=False, debug=0, errorlog=yacc.NullLogger())
 
-    return p.parse(preprocessed_data, lexer=lexer)
+    policy = p.parse(data, lexer=lexer, tokenfunc=tokenfunc)
+    policy.filename = filename
+    return policy
 
   except IndexError:
     return False

--- a/namelint.py
+++ b/namelint.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# Copyright 2008 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+import argparse
+
+from lib.linters import build_linters, severity as sev
+from lib.naming import Naming
+
+__author__ = 'mikeelkin2@fb.com (Mike Elkin)'
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument('file', nargs='+', type=str,
+                      metavar='SOMETHING.net',
+                      help="NETWORK/SERVICE file to run against")
+  parser.add_argument('-c', '--config',
+                      help="YAML configuration file (optional)")
+  parser.add_argument('-o', '--output', choices=['pretty', 'plain', 'json'],
+                      default='pretty', help="Output format")
+  ns = parser.parse_args()
+
+  errors, linters = build_linters(ns.config)
+
+  for filename in ns.file:
+    fn = os.path.abspath(os.path.expanduser(filename))
+    errors.filename = filename
+    if filename.endswith('.svc'):
+      svctype = 'services'
+    elif filename.endswith('.net'):
+      svctype = 'networks'
+    else:
+      errors.add(sev.ERROR, 'Unknown extension: %s' % filename)
+      continue
+
+    try:
+      processed = Naming(naming_dir='/', naming_file=fn, naming_type=svctype)
+    except Exception as e:
+      errors.add(sev.ERROR, '%s had exception: %s' % (filename, e))
+      continue
+
+    for linter in linters:
+      linter.lint_naming(processed)
+
+  if ns.output == 'pretty':
+    errors.pprint()
+  elif ns.output == 'plain':
+    errors.plain()
+  elif ns.output == 'json':
+    errors.json()
+
+if __name__ == '__main__':
+  main()

--- a/namelint.py
+++ b/namelint.py
@@ -21,10 +21,9 @@ from __future__ import unicode_literals
 import os
 import argparse
 
-from lib.linters import build_linters, severity as sev
+from lib.linters import build_linters
+from lib.linters import Severity as sev
 from lib.naming import Naming
-
-__author__ = 'mikeelkin2@fb.com (Mike Elkin)'
 
 
 def main():

--- a/policies/lint/example_lint.yaml
+++ b/policies/lint/example_lint.yaml
@@ -1,0 +1,5 @@
+IndentEnforcer:
+  enabled: false
+
+RegexNameEnforcer:
+  NETNAME: ".*"

--- a/pollint.py
+++ b/pollint.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# Copyright 2008 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import os
+
+from lib.linters import build_linters, severity as sev
+from lib.naming import Naming
+from lib.policy import ParsePolicy, _ReadFile
+
+__author__ = 'mikeelkin2@fb.com (Mike Elkin)'
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument('file', nargs='+', type=str,
+                      metavar='SOMETHING.pol',
+                      help="Policy file to run against")
+  parser.add_argument('-c', '--config',
+                      help="YAML configuration file (optional)")
+  parser.add_argument('-o', '--output', choices=['pretty', 'plain', 'json'],
+                      default='pretty', help="Output format")
+  parser.add_argument('-d', '--definitions', help="Definitions directory")
+  ns = parser.parse_args()
+
+  errors, linters = build_linters(ns.config)
+
+  definitions = Naming(naming_dir=ns.definitions)
+
+  for filename in ns.file:
+    fn = os.path.abspath(os.path.expanduser(filename))
+    errors.filename = filename
+    try:
+      d = _ReadFile(fn)
+      if filename.endswith('.inc'):
+        # included files do not have headers in them,
+        # which breaks token parsing - so we add in a blank header
+        d = 'header { } ' + d
+      p = ParsePolicy(d, definitions, track=True, optimize=False,
+                      filename=filename)
+    except Exception as e:
+      msg = '%s encountered an exception: %s' % (filename, str(e))
+      errors.add(sev.ERROR, msg)
+      continue
+
+    for linter in linters:
+      linter.lint_policy(p)
+
+  if ns.output == 'pretty':
+    errors.pprint()
+  elif ns.output == 'plain':
+    errors.plain()
+  elif ns.output == 'json':
+    errors.json()
+
+if __name__ == '__main__':
+    main()

--- a/pollint.py
+++ b/pollint.py
@@ -21,7 +21,8 @@ from __future__ import unicode_literals
 import argparse
 import os
 
-from lib.linters import build_linters, severity as sev
+from lib.linters import Severity as sev
+from lib.linters import build_linters
 from lib.naming import Naming
 from lib.policy import ParsePolicy, _ReadFile
 

--- a/tests/linters_test.py
+++ b/tests/linters_test.py
@@ -1,0 +1,176 @@
+# Copyright 2008 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from lib import linters
+from lib import naming
+from lib import policy
+
+class BaseLintTest(unittest.TestCase):
+
+  """Base helper class for linters. Use self.linter to access a linter -
+  and self.lint_errors to look at the errors produced."""
+
+  LINTER_CLASS = None
+  LINT_CONFIG = {}
+
+  def setUp(self):
+    errors = linters.LintErrors()
+    self.linter = self.LINTER_CLASS(errors, self.LINT_CONFIG)
+
+  @property
+  def lint_errors(self):
+    return self.linter.errors.errs
+
+  def loadNaming(self, def_type, content, defs=None):
+
+    """Load the given naming definition type and string blob"""
+
+    defs = defs or naming.Naming(None)
+    for lineno, line in enumerate(content.splitlines(), start=1):
+      defs._ParseLine(line, def_type, lineno=lineno)
+    return defs
+
+  def loadPolicy(self, net_content, svc_content, policy_content,
+                 filename='unittest'):
+
+    """Load the provided string blobs into a tracked parsed policy"""
+
+    defs = naming.Naming(None)
+    self.loadNaming('networks', net_content, defs=defs)
+    self.loadNaming('services', svc_content, defs=defs)
+    p = policy.ParsePolicy(
+      policy_content,
+      defs,
+      track=True,
+      optimize=False,
+      filename=filename,
+    )
+    return p
+
+  def assertOneLintError(self):
+    self.assertEquals(len(self.lint_errors), 1)
+
+  def assertLintMessage(self, msg):
+    self.assertEquals(self.lint_errors[0].message, msg)
+
+
+NAMING_NETWORKS = """
+NET_TEN_EIGHT = 10.0.0.0/8
+NET_TWO_EIGHT = 2.0.0.0/8
+"""
+
+BAD_NAMING_NETWORKS = """
+lowercase_network = 1.1.1.1/32
+GARBAGE.DOT = 2.2.2.2/32
+"""
+
+NAMING_SVC = """
+SSH = 22/tcp
+"""
+
+GOOD_POLICY = """
+header {
+}
+
+term good-term-1 {
+  action:: accept
+}
+"""
+
+BAD_POLICY = """
+header {
+}
+term BAD-TERM {
+  action:: accept
+}
+"""
+
+class NameEnforcerTest(BaseLintTest):
+  LINTER_CLASS = linters.RegexNameEnforcer
+
+  def test_good_naming(self):
+    defs = self.loadNaming('networks', NAMING_NETWORKS)
+    self.loadNaming('services', NAMING_SVC, defs=defs)
+    self.linter.lint_naming(defs)
+    self.assertEquals(self.linter.errors.errs, [])
+
+  def test_bad_naming(self):
+    defs = self.loadNaming('networks', BAD_NAMING_NETWORKS)
+    self.loadNaming('services', NAMING_SVC, defs=defs)
+    self.linter.lint_naming(defs)
+
+    expected = set([
+      'lowercase_network is not a valid network name',
+      'GARBAGE.DOT is not a valid network name',
+    ])
+    found = set([x.message for x in self.lint_errors])
+    self.assertEquals(expected, found)
+
+  def test_good_policy(self):
+    p = self.loadPolicy(NAMING_NETWORKS, NAMING_SVC, GOOD_POLICY)
+    self.linter.lint_policy(p)
+    self.assertEquals(self.lint_errors, [])
+
+  def test_bad_policy(self):
+    p = self.loadPolicy(NAMING_NETWORKS, NAMING_SVC, BAD_POLICY)
+    self.linter.lint_policy(p)
+    self.assertOneLintError()
+    self.assertLintMessage('BAD-TERM is not a valid term name for all platforms')
+
+
+SAMELINE_NET = """TWO_NETWORKS = 1.1.1.1/32 2.2.2.2/32"""
+SAMELINE_SVC = """TCP_SSH = 22/tcp 22/udp"""
+
+class SameLineEnforcerTest(BaseLintTest):
+  LINTER_CLASS = linters.SameLineDefinitionsEnforcer
+
+  def test_singleline_network(self):
+    defs = self.loadNaming('networks', SAMELINE_NET)
+    self.linter.lint_naming(defs)
+    self.assertOneLintError()
+    self.assertLintMessage('Networks on same line')
+
+  def test_singleline_service(self):
+    defs = self.loadNaming('services', SAMELINE_SVC)
+    self.linter.lint_naming(defs)
+    self.assertOneLintError()
+    self.assertLintMessage('Services on same line')
+
+
+LONG_NETWORK_NAMING = """THIS_IS_A_LONG_NETWORK = 1.1.1.1/32"""
+LONG_SERVICE_NAMING = """THIS_IS_A_LONG_SERVICE = 22/tcp"""
+
+class CharLengthEnforcerTest(BaseLintTest):
+  LINTER_CLASS = linters.CharLengthEnforcer
+  LINT_CONFIG = {
+    'CharLengthEnforcer': {
+      'MAX_NETWORK_LEN': 10,
+      'MAX_SERVICE_LEN': 10,
+    }
+  }
+
+  def test_long_network(self):
+    defs = self.loadNaming('networks', LONG_NETWORK_NAMING)
+    self.linter.lint_naming(defs)
+    self.assertOneLintError()
+
+  def test_long_service(self):
+    defs = self.loadNaming('services', LONG_SERVICE_NAMING)
+    self.linter.lint_naming(defs)
+    self.assertOneLintError()
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Summary: This adds linting support to Capirca. Linting is helpful to integrate to SDLC tooling and to ensure compliance to basic style guides, and can be used as an alternative to some of the common warnings when running aclgen. The README.md updates covers the use cases in more depth, as well as an example of the default style guide.

Test Plan: Ran linter against sample policies, boilerplate include file, and network/service definitions. Unit test offers some basic coverage on common linters.
