### PR TITLE
Filecomment lexxer support

### DIFF
--- a/lib/cisco.py
+++ b/lib/cisco.py
@@ -829,6 +829,9 @@ class Cisco(aclgenerator.ACLGenerator):
           for line in comment.split('\n'):
             target.append('remark %s' % line)
 
+        for line in header.filecomment:
+          target_header.append("! %s !" % line.replace('"', ""))
+
         # now add the terms
         for term in terms:
           term_str = str(term)

--- a/lib/juniper.py
+++ b/lib/juniper.py
@@ -776,6 +776,7 @@ class Juniper(aclgenerator.ACLGenerator):
 
   def _TranslatePolicy(self, pol, exp_info):
     self.juniper_policies = []
+    self.file_comment = []
     current_date = datetime.datetime.utcnow().date()
     exp_info_date = current_date + datetime.timedelta(weeks=exp_info)
 
@@ -800,6 +801,9 @@ class Juniper(aclgenerator.ACLGenerator):
       filter_type = 'inet'
       if len(filter_options) > 1:
         filter_type = filter_options[1]
+
+      if header.filecomment:
+        self.file_comment = header.filecomment
 
       term_names = set()
       new_terms = []
@@ -833,6 +837,11 @@ class Juniper(aclgenerator.ACLGenerator):
 
     for (header, filter_name, filter_type, interface_specific, terms
         ) in self.juniper_policies:
+      # add file-comments from header
+      for fc in self.file_comment:
+        fc = fc.replace('"', "")
+        config.Append('/* %s */' % fc)
+
       # add the header information
       config.Append('firewall {')
       config.Append('family %s {' % filter_type)

--- a/lib/junipersrx.py
+++ b/lib/junipersrx.py
@@ -316,6 +316,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
     self.from_zone = ''
     self.to_zone = ''
     self.addr_book_type_global = True
+    self.file_comment = []
 
     current_date = datetime.datetime.utcnow().date()
     exp_info_date = current_date + datetime.timedelta(weeks=exp_info)
@@ -327,6 +328,9 @@ class JuniperSRX(aclgenerator.ACLGenerator):
     for header, terms in pol.filters:
       if self._PLATFORM not in header.platforms:
         continue
+
+      if header.filecomment:
+        self.file_comment = header.filecomment
 
       filter_options = header.FilterOptions(self._PLATFORM)
 
@@ -761,6 +765,12 @@ class JuniperSRX(aclgenerator.ACLGenerator):
   def __str__(self):
     """Render the output of the JuniperSRX policy into config."""
     target = []
+
+    # add file comments
+    for fc in self.file_comment:
+      fc = fc.replace('"', "")
+      target.append('/* %s */' % fc)
+
     target.append('security {')
 
     # ADDRESSBOOK

--- a/lib/policy.py
+++ b/lib/policy.py
@@ -1290,6 +1290,7 @@ class VarType(object):
   DTAG = 45
   NEXT_IP = 46
   HOP_LIMIT = 47
+  FILECOMMENT = 48
 
   def __init__(self, var_type, value):
     self.var_type = var_type
@@ -1319,13 +1320,14 @@ class Header(object):
     self.comment = []
     self.apply_groups = []
     self.apply_groups_except = []
+    self.filecomment = []
 
   def AddObject(self, obj):
     """Add and object to the Header.
 
     Args:
       obj: of type VarType.COMMENT, VarType.APPLY_GROUPS,
-      VarType.APPLY_GROUPS_EXCEPT, or Target
+      VarType.APPLY_GROUPS_EXCEPT, VarType.FILECOMMENT, or Target
 
     Raises:
       RuntimeError: if object type cannot be determined
@@ -1340,6 +1342,8 @@ class Header(object):
           self.apply_groups_except.append(str(x))
     elif obj.var_type == VarType.COMMENT:
       self.comment.append(str(obj))
+    elif obj.var_type == VarType.FILECOMMENT:
+      self.filecomment.append(str(obj))
     else:
       raise RuntimeError('Unable to add object from header.')
 
@@ -1466,6 +1470,7 @@ tokens = (
     'EXPIRATION',
     'FORWARDING_CLASS',
     'FRAGMENT_OFFSET',
+    'FILECOMMENT',
     'HOP_LIMIT',
     'APPLY_GROUPS',
     'APPLY_GROUPS_EXCEPT',
@@ -1525,6 +1530,7 @@ reserved = {
     'expiration': 'EXPIRATION',
     'forwarding-class': 'FORWARDING_CLASS',
     'fragment-offset': 'FRAGMENT_OFFSET',
+    'file-comment': 'FILECOMMENT',
     'hop-limit': 'HOP_LIMIT',
     'apply-groups': 'APPLY_GROUPS',
     'apply-groups-except': 'APPLY_GROUPS_EXCEPT',
@@ -1644,6 +1650,7 @@ def p_header_spec(p):
                   | header_spec comment_spec
                   | header_spec apply_groups_spec
                   | header_spec apply_groups_except_spec
+                  | header_spec filecomment_spec
                   | """
   if len(p) > 1:
     if type(p[1]) == Header:
@@ -2003,6 +2010,11 @@ def p_apply_groups_except_spec(p):
   p[0] = []
   for group_except in p[4]:
     p[0].append(VarType(VarType.APPLY_GROUPS_EXCEPT, group_except))
+
+
+def p_filecomment_spec(p):
+    """ filecomment_spec : FILECOMMENT ':' ':' DQUOTEDSTRING """
+    p[0] = VarType(VarType.FILECOMMENT, p[4])
 
 
 def p_timeout_spec(p):

--- a/tests/aclgenerator_test.py
+++ b/tests/aclgenerator_test.py
@@ -26,6 +26,7 @@ GOOD_HEADER_1 = """
 header {
   comment:: "this is a test acl"
   target:: mock
+  file-comment:: "meh"
 }
 """
 

--- a/tests/cisco_test.py
+++ b/tests/cisco_test.py
@@ -30,6 +30,7 @@ GOOD_HEADER = """
 header {
   comment:: "this is a test acl"
   target:: cisco test-filter
+  file-comment:: "test file comment"
 }
 """
 GOOD_STANDARD_HEADER_1 = """

--- a/tests/juniper_test.py
+++ b/tests/juniper_test.py
@@ -34,6 +34,7 @@ GOOD_HEADER = """
 header {
   comment:: "this is a test acl"
   target:: juniper test-filter
+  file-comment:: "test file comment"
 }
 """
 GOOD_HEADER_2 = """

--- a/tests/junipersrx_test.py
+++ b/tests/junipersrx_test.py
@@ -31,6 +31,7 @@ GOOD_HEADER = """
 header {
   comment:: "This is a test acl with a comment"
   target:: srx from-zone trust to-zone untrust
+  file-comment:: "test file comment"
 }
 """
 GOOD_HEADER_2 = """


### PR DESCRIPTION
Summary:
It can be useful to sometimes embed arbitrary comments at the very top of
the file, rather than a few lines in via a header comment. This is supported
with a "file-comment" header attribute that on supported platforms will include
that content at the very top of the generated policy.

Test Plan:
Added new token to aclgenerator unit test - unittest did not
crash.
