### PR TITLE
Fix nsxv unittest

### DIFF
--- a/tests/lib/nsxv_unittest.py
+++ b/tests/lib/nsxv_unittest.py
@@ -44,14 +44,12 @@ class TermTest(unittest.TestCase):
     """ Test for Term._init_ """
     inet_term = nsxv.Term(nsxv_mocktest.INET_TERM, 'inet')
     self.assertEqual(inet_term.af, 4)
-    self.assertEqual(inet_term.text_af, 'inet')
     self.assertEqual(inet_term.filter_type, 'inet')
 
   def test_init_forinet6(self):
     """ Test for Term._init_ """
     inet6_term = nsxv.Term(nsxv_mocktest.INET6_TERM, 'inet6', 6)
     self.assertEqual(inet6_term.af, 6)
-    self.assertEqual(inet6_term.text_af, 'inet6')
     self.assertEqual(inet6_term.filter_type, 'inet6')
 
   def test_ServiceToStr(self):


### PR DESCRIPTION
Summary:
The nsxv unittest was referencing a text address family
attribute that seems to be Cisco-specific, which is not implemented by
this platform.

Test Plan:
ran all test*.py modules in tests/ directory and saw this
passed.
