### PR TITLE
fix broken characterization tests

### DIFF
--- a/tests/characterization_data/filters_expected/sample_cisco_lab.acl
+++ b/tests/characterization_data/filters_expected/sample_cisco_lab.acl
@@ -3,49 +3,49 @@
 ! $Revision:$
 no ip access-list extended allowtointernet
 ip access-list extended allowtointernet
-remark $Id:$
-remark Denies all traffic to internal IPs except established tcp replies.
-remark Also denies access to certain public allocations.
-remark Ideal for some internal lab/testing types of subnets that are
-remark not well trusted, but allowing internal users to access.
-remark Apply to ingress interface (to filter traffic coming from lab)
+ remark $Id:$
+ remark Denies all traffic to internal IPs except established tcp replies.
+ remark Also denies access to certain public allocations.
+ remark Ideal for some internal lab/testing types of subnets that are
+ remark not well trusted, but allowing internal users to access.
+ remark Apply to ingress interface (to filter traffic coming from lab)
 
 
-remark accept-dhcp
-remark Optional - allow forwarding of DHCP requests.
+ remark accept-dhcp
+ remark Optional - allow forwarding of DHCP requests.
  permit 17 any any eq 67
  permit 17 any any eq 68
 
 
-remark accept-to-honestdns
-remark Allow name resolution using honestdns.
+ remark accept-to-honestdns
+ remark Allow name resolution using honestdns.
  permit 17 any host 8.8.4.4 eq 53
  permit 17 any host 8.8.8.8 eq 53
 
 
-remark accept-tcp-replies
-remark Allow tcp replies to internal hosts.
+ remark accept-tcp-replies
+ remark Allow tcp replies to internal hosts.
  permit 6 any 10.0.0.0 0.255.255.255 established
  permit 6 any 172.16.0.0 0.15.255.255 established
  permit 6 any 192.168.0.0 0.0.255.255 established
 
 
-remark deny-to-internal
-remark Deny access to rfc1918/internal.
+ remark deny-to-internal
+ remark Deny access to rfc1918/internal.
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 172.16.0.0 0.15.255.255
  deny ip any 192.168.0.0 0.0.255.255
 
 
-remark deny-to-specific_hosts
-remark Deny access to specified public.
+ remark deny-to-specific_hosts
+ remark Deny access to specified public.
  deny ip any host 200.1.1.1
  deny ip any host 200.1.1.2
  deny ip any 200.1.1.4 0.0.0.1
 
 
-remark default-permit
-remark Allow what's left.
+ remark default-permit
+ remark Allow what's left.
  permit ip any any
 
 exit

--- a/tests/characterization_data/filters_expected/sample_multitarget.acl
+++ b/tests/characterization_data/filters_expected/sample_multitarget.acl
@@ -3,15 +3,15 @@
 ! $Revision:$
 no ip access-list extended edge-inbound
 ip access-list extended edge-inbound
-remark $Id:$
-remark this is a sample edge input filter that generates
-remark multiple output formats.
+ remark $Id:$
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
 
 
-remark deny-from-bogons
-remark this is a sample edge input filter with a very very very long and
-remark multi-line comment that
-remark also has multiple entries.
+ remark deny-from-bogons
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 192.0.0.0 0.0.0.255 any
  deny ip 192.0.2.0 0.0.0.255 any
@@ -22,7 +22,7 @@ remark also has multiple entries.
  deny ip 240.0.0.0 15.255.255.255 any
 
 
-remark deny-from-reserved
+ remark deny-from-reserved
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 10.0.0.0 0.255.255.255 any
  deny ip 100.64.0.0 0.63.255.255 any
@@ -33,78 +33,78 @@ remark deny-from-reserved
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-to-rfc1918
+ remark deny-to-rfc1918
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 172.16.0.0 0.15.255.255
  deny ip any 192.168.0.0 0.0.255.255
 
 
-remark permit-mail-services
+ remark permit-mail-services
  permit 6 any 200.1.1.4 0.0.0.1 eq 25
  permit 6 any 200.1.1.4 0.0.0.1 eq 465
  permit 6 any 200.1.1.4 0.0.0.1 eq 587
  permit 6 any 200.1.1.4 0.0.0.1 eq 995
 
 
-remark permit-web-services
+ remark permit-web-services
  permit 6 any host 200.1.1.1 eq 80
  permit 6 any host 200.1.1.1 eq 443
  permit 6 any host 200.1.1.2 eq 80
  permit 6 any host 200.1.1.2 eq 443
 
 
-remark permit-tcp-established
+ remark permit-tcp-established
  permit 6 any host 200.1.1.1 established
  permit 6 any 200.1.1.2 0.0.0.1 established
  permit 6 any 200.1.1.4 0.0.0.1 established
 
 
-remark permit-udp-established
+ remark permit-udp-established
  permit 17 any range 1024 65535 host 200.1.1.1
  permit 17 any range 1024 65535 200.1.1.2 0.0.0.1
  permit 17 any range 1024 65535 200.1.1.4 0.0.0.1
 
 
-remark default-deny
+ remark default-deny
  deny ip any any
 
 exit
 
 no ipv6 access-list ipv6-edge-inbound
 ipv6 access-list ipv6-edge-inbound
-remark $Id:$
-remark this is a sample edge input filter that generates
-remark multiple output formats.
+ remark $Id:$
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
 
 
-remark deny-from-bogons
-remark this is a sample edge input filter with a very very very long and
-remark multi-line comment that
-remark also has multiple entries.
+ remark deny-from-bogons
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
  deny ipv6 2001:db8::/32 any
  deny ipv6 3ffe::/16 any
  deny ipv6 5f00::/8 any
  deny ipv6 ff00::/8 any
 
 
-remark deny-from-reserved
+ remark deny-from-reserved
  deny ipv6 ::/3 any
  deny ipv6 4000::/2 any
  deny ipv6 8000::/1 any
 
 
-remark default-deny
+ remark default-deny
  deny ipv6 any any
 
 exit
 
 no ip access-list extended edge-outbound
 ip access-list extended edge-outbound
-remark $Id:$
-remark this is a sample output filter
+ remark $Id:$
+ remark this is a sample output filter
 
 
-remark deny-to-bad-destinations
+ remark deny-to-bad-destinations
  deny ip any 0.0.0.0 0.255.255.255
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 100.64.0.0 0.63.255.255
@@ -120,18 +120,18 @@ remark deny-to-bad-destinations
  deny ip any 224.0.0.0 31.255.255.255
 
 
-remark default-accept
+ remark default-accept
  permit ip any any
 
 exit
 
 no ipv6 access-list ipv6-edge-outbound
 ipv6 access-list ipv6-edge-outbound
-remark $Id:$
-remark this is a sample output filter
+ remark $Id:$
+ remark this is a sample output filter
 
 
-remark deny-to-bad-destinations
+ remark deny-to-bad-destinations
  deny ipv6 any ::/3
  deny ipv6 any 2001:db8::/32
  deny ipv6 any 3ffe::/16
@@ -139,7 +139,7 @@ remark deny-to-bad-destinations
  deny ipv6 any 8000::/1
 
 
-remark default-accept
+ remark default-accept
  permit ipv6 any any
 
 exit

--- a/tests/characterization_data/filters_expected/sample_multitarget.bacl
+++ b/tests/characterization_data/filters_expected/sample_multitarget.bacl
@@ -3,14 +3,14 @@
 ! $Revision:$
 no ip access-list extended edge-inbound
 ip access-list extended edge-inbound
-remark $Id:$
-remark this is a sample edge input filter that generates
-remark multiple output formats.
+ remark $Id:$
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
 
 
-remark this is a sample edge input filter with a very very very long and
-remark multi-line comment that
-remark also has multiple entries.
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 192.0.0.0 0.0.0.255 any
  deny ip 192.0.2.0 0.0.0.255 any

--- a/tests/characterization_data/filters_expected/sample_multitarget.eacl
+++ b/tests/characterization_data/filters_expected/sample_multitarget.eacl
@@ -3,15 +3,15 @@
 ! $Revision:$
 no ip access-list edge-inbound
 ip access-list edge-inbound
-remark $Id:$
-remark this is a sample edge input filter that generates
-remark multiple output formats.
+ remark $Id:$
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
 
 
-remark deny-from-bogons
-remark this is a sample edge input filter with a very very very long and
-remark multi-line comment that
-remark also has multiple entries.
+ remark deny-from-bogons
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 192.0.0.0 0.0.0.255 any
  deny ip 192.0.2.0 0.0.0.255 any
@@ -22,7 +22,7 @@ remark also has multiple entries.
  deny ip 240.0.0.0 15.255.255.255 any
 
 
-remark deny-from-reserved
+ remark deny-from-reserved
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 10.0.0.0 0.255.255.255 any
  deny ip 100.64.0.0 0.63.255.255 any
@@ -33,39 +33,39 @@ remark deny-from-reserved
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-to-rfc1918
+ remark deny-to-rfc1918
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 172.16.0.0 0.15.255.255
  deny ip any 192.168.0.0 0.0.255.255
 
 
-remark permit-mail-services
+ remark permit-mail-services
  permit tcp any 200.1.1.4 0.0.0.1 eq 25
  permit tcp any 200.1.1.4 0.0.0.1 eq 465
  permit tcp any 200.1.1.4 0.0.0.1 eq 587
  permit tcp any 200.1.1.4 0.0.0.1 eq 995
 
 
-remark permit-web-services
+ remark permit-web-services
  permit tcp any host 200.1.1.1 eq 80
  permit tcp any host 200.1.1.1 eq 443
  permit tcp any host 200.1.1.2 eq 80
  permit tcp any host 200.1.1.2 eq 443
 
 
-remark permit-tcp-established
+ remark permit-tcp-established
  permit tcp any host 200.1.1.1 established
  permit tcp any 200.1.1.2 0.0.0.1 established
  permit tcp any 200.1.1.4 0.0.0.1 established
 
 
-remark permit-udp-established
+ remark permit-udp-established
  permit udp any range 1024 65535 host 200.1.1.1
  permit udp any range 1024 65535 200.1.1.2 0.0.0.1
  permit udp any range 1024 65535 200.1.1.4 0.0.0.1
 
 
-remark default-deny
+ remark default-deny
  deny ip any any
 
 exit

--- a/tests/characterization_data/filters_expected/sample_multitarget.xacl
+++ b/tests/characterization_data/filters_expected/sample_multitarget.xacl
@@ -3,15 +3,15 @@
 ! $Revision:$
 no ipv4 access-list edge-inbound
 ipv4 access-list edge-inbound
-remark $Id:$
-remark this is a sample edge input filter that generates
-remark multiple output formats.
+ remark $Id:$
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
 
 
-remark deny-from-bogons
-remark this is a sample edge input filter with a very very very long and
-remark multi-line comment that
-remark also has multiple entries.
+ remark deny-from-bogons
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 192.0.0.0 0.0.0.255 any
  deny ip 192.0.2.0 0.0.0.255 any
@@ -22,7 +22,7 @@ remark also has multiple entries.
  deny ip 240.0.0.0 15.255.255.255 any
 
 
-remark deny-from-reserved
+ remark deny-from-reserved
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 10.0.0.0 0.255.255.255 any
  deny ip 100.64.0.0 0.63.255.255 any
@@ -33,39 +33,39 @@ remark deny-from-reserved
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-to-rfc1918
+ remark deny-to-rfc1918
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 172.16.0.0 0.15.255.255
  deny ip any 192.168.0.0 0.0.255.255
 
 
-remark permit-mail-services
+ remark permit-mail-services
  permit 6 any 200.1.1.4 0.0.0.1 eq 25
  permit 6 any 200.1.1.4 0.0.0.1 eq 465
  permit 6 any 200.1.1.4 0.0.0.1 eq 587
  permit 6 any 200.1.1.4 0.0.0.1 eq 995
 
 
-remark permit-web-services
+ remark permit-web-services
  permit 6 any host 200.1.1.1 eq 80
  permit 6 any host 200.1.1.1 eq 443
  permit 6 any host 200.1.1.2 eq 80
  permit 6 any host 200.1.1.2 eq 443
 
 
-remark permit-tcp-established
+ remark permit-tcp-established
  permit 6 any host 200.1.1.1 established
  permit 6 any 200.1.1.2 0.0.0.1 established
  permit 6 any 200.1.1.4 0.0.0.1 established
 
 
-remark permit-udp-established
+ remark permit-udp-established
  permit 17 any range 1024 65535 host 200.1.1.1
  permit 17 any range 1024 65535 200.1.1.2 0.0.0.1
  permit 17 any range 1024 65535 200.1.1.4 0.0.0.1
 
 
-remark default-deny
+ remark default-deny
  deny ip any any
 
 exit


### PR DESCRIPTION
fix MOE_MIGRATED_REVID=131342769, it broke all characterization tests that utilized the cisco.py platfrom generator.