### PR TITLE
add __future__ to all python files to support python2.7/3 code

### DIFF
--- a/aclcheck_cmdline.py
+++ b/aclcheck_cmdline.py
@@ -15,6 +15,11 @@
 
 """Command line interface to aclcheck library."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'watson@google.com (Tony Watson)'
 
 from optparse import OptionParser

--- a/aclgen.py
+++ b/aclgen.py
@@ -18,6 +18,11 @@
 
 """Renders policy source files into actual Access Control Lists."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'pmoody@google.com'
 
 import copy

--- a/cgrep.py
+++ b/cgrep.py
@@ -36,6 +36,10 @@
 #   To find which service tokens contain port '22' and protocol 'tcp' use
 #   $ cgrep.py -p 22 tcp
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import argparse
 import pprint

--- a/definate.py
+++ b/definate.py
@@ -18,6 +18,10 @@ Definate is a framework to generate definitions for the automatic network policy
 generation framework. The definitions are generated based on a configuration
 file.
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 __author__ = 'msu@google.com (Martin Suess)'
 

--- a/definate/definition_filter.py
+++ b/definate/definition_filter.py
@@ -16,6 +16,11 @@
 
 """Module that holds all definition-level filter classes of Definate."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'msu@google.com (Martin Suess)'
 
 

--- a/definate/dns_generator.py
+++ b/definate/dns_generator.py
@@ -16,6 +16,11 @@
 
 """Generator for DNS based network definitions."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'msu@google.com (Martin Suess)'
 
 

--- a/definate/file_filter.py
+++ b/definate/file_filter.py
@@ -16,6 +16,11 @@
 
 """Module that holds all file-level filter classes of Definate."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'msu@google.com (Martin Suess)'
 
 

--- a/definate/filter_factory.py
+++ b/definate/filter_factory.py
@@ -16,6 +16,11 @@
 
 """Functionality to allow easily retrieving certain filter objects."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'msu@google.com (Martin Suess)'
 
 

--- a/definate/generator.py
+++ b/definate/generator.py
@@ -16,6 +16,11 @@
 
 """Module holding the abstract definition generator class."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'msu@google.com (Martin Suess)'
 
 

--- a/definate/generator_factory.py
+++ b/definate/generator_factory.py
@@ -16,6 +16,11 @@
 
 """Functionality to allow easily retrieving the right definition generator."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'msu@google.com (Martin Suess)'
 
 

--- a/definate/global_filter.py
+++ b/definate/global_filter.py
@@ -16,6 +16,11 @@
 
 """Module that holds all global-level filter classes of Definate."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'msu@google.com (Martin Suess)'
 
 

--- a/definate/yaml_validator.py
+++ b/definate/yaml_validator.py
@@ -16,6 +16,11 @@
 
 """Tools to allow the verification of the YAML configuration for Definate."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'msu@google.com (Martin Suess)'
 
 

--- a/lib/aclcheck.py
+++ b/lib/aclcheck.py
@@ -15,7 +15,13 @@
 
 """Check where hosts, ports and protocols are matched in a capirca policy."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'watson@google.com (Tony Watson)'
+
 
 import logging
 from lib import nacaddr

--- a/lib/aclgenerator.py
+++ b/lib/aclgenerator.py
@@ -15,6 +15,11 @@
 
 """ACL Generator base class."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import copy
 import logging
 import re

--- a/lib/arista.py
+++ b/lib/arista.py
@@ -15,6 +15,11 @@
 
 """Arista generator."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'ryanshea@google.com (Ryan Shea)'
 
 from lib import cisco

--- a/lib/aruba.py
+++ b/lib/aruba.py
@@ -20,6 +20,11 @@ The word beta is very generous too: this only outputs a
 very, very limited subset of possible acls.
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'cburgoyne@google.com (Chris Burgoyne)'
 
 import logging

--- a/lib/brocade.py
+++ b/lib/brocade.py
@@ -15,6 +15,11 @@
 
 """Brocade generator."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'ryanshea@google.com (Ryan Shea)'
 
 from lib import cisco

--- a/lib/cisco.py
+++ b/lib/cisco.py
@@ -15,6 +15,11 @@
 
 """Cisco generator."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = ['pmoody@google.com (Peter Moody)',
               'watson@google.com (Tony Watson)']
 

--- a/lib/ciscoasa.py
+++ b/lib/ciscoasa.py
@@ -15,6 +15,11 @@
 
 """Cisco ASA renderer."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'antony@slac.stanford.edu (Antonio Ceseracciu)'
 
 import datetime

--- a/lib/ciscoxr.py
+++ b/lib/ciscoxr.py
@@ -15,6 +15,11 @@
 
 """Cisco IOS-XR filter renderer."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'robankeny@google.com (Robert Ankeny)'
 
 from lib import cisco

--- a/lib/demo.py
+++ b/lib/demo.py
@@ -14,6 +14,11 @@
 #
 """Demo generator for capirca."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'robankeny@google.com (Robert Ankeny)'
 
 

--- a/lib/gce.py
+++ b/lib/gce.py
@@ -20,6 +20,11 @@ https://cloud.google.com/compute/docs/networking
 https://cloud.google.com/compute/docs/reference/latest/firewalls
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'msu@google.com (Martin Suess)'
 
 

--- a/lib/ipset.py
+++ b/lib/ipset.py
@@ -20,6 +20,11 @@ performace of iptables firewall.
 
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'vklimovs@google.com (Vjaceslavs Klimovs)'
 
 import string

--- a/lib/iptables.py
+++ b/lib/iptables.py
@@ -15,6 +15,11 @@
 
 """Iptables generator."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'watson@google.com (Tony Watson)'
 
 import datetime

--- a/lib/juniper.py
+++ b/lib/juniper.py
@@ -15,6 +15,11 @@
 
 """Juniper JCL generator."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = ['pmoody@google.com (Peter Moody)',
               'watson@google.com (Tony Watson)']
 

--- a/lib/junipersrx.py
+++ b/lib/junipersrx.py
@@ -16,6 +16,11 @@
 """SRX generator."""
 # pylint: disable=super-init-not-called
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'robankeny@google.com (Robert Ankeny)'
 
 import collections

--- a/lib/nacaddr.py
+++ b/lib/nacaddr.py
@@ -15,6 +15,11 @@
 
 """A subclass of the ipaddr library that includes comments for ipaddr."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'watson@google.com (Tony Watson)'
 
 import ipaddr

--- a/lib/naming.py
+++ b/lib/naming.py
@@ -44,6 +44,11 @@ DNS = 53/tcp
 
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import glob
 import os
 

--- a/lib/nftables.py
+++ b/lib/nftables.py
@@ -22,6 +22,11 @@ generator inherits directly from aclgenerator.
 
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'vklimovs@google.com (Vjaceslavs Klimovs)'
 
 import collections

--- a/lib/nsxv.py
+++ b/lib/nsxv.py
@@ -15,6 +15,11 @@
 
 """Nsxv generator."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import datetime
 import re
 

--- a/lib/packetfilter.py
+++ b/lib/packetfilter.py
@@ -15,6 +15,11 @@
 
 """PacketFilter (PF) generator."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'msu@google.com (Martin Suess)'
 
 import collections

--- a/lib/pcap.py
+++ b/lib/pcap.py
@@ -27,6 +27,11 @@ having more confidence in it.
 Stolen liberally from packetfilter.py.
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import datetime
 
 from lib import aclgenerator

--- a/lib/policy.py
+++ b/lib/policy.py
@@ -16,6 +16,11 @@
 """Parses the generic policy files and return a policy object for acl rendering.
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = ['pmoody@google.com',
               'watson@google.com']
 
@@ -1600,7 +1605,7 @@ def t_newline(t):
 
 
 def t_error(t):
-  print "Illegal character '%s' on line %s" % (t.value[0], t.lineno)
+  print("Illegal character '%s' on line %s") % (t.value[0], t.lineno)
   t.lexer.skip(1)
 
 

--- a/lib/policy_simple.py
+++ b/lib/policy_simple.py
@@ -21,6 +21,11 @@ inline comments but preservers line-level comments. Fields expected to have
 "naming" values are stored as a set without order or line breaks retained.
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import logging
 
 

--- a/lib/policyreader.py
+++ b/lib/policyreader.py
@@ -24,6 +24,11 @@ TODO: This library is currently incomplete, and does not allow access to
       every argument of a policy term.
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'watson@google.com (Tony Watson)'
 
 from lib import naming

--- a/lib/port.py
+++ b/lib/port.py
@@ -15,6 +15,11 @@
 
 """Common library for network ports and protocol handling."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 
 class Error(Exception):
   """Base error class."""

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -15,6 +15,11 @@
 # limitations under the License.
 #
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from distutils.core import setup
 
 import capirca

--- a/lib/speedway.py
+++ b/lib/speedway.py
@@ -15,6 +15,11 @@
 
 """Speedway iptables generator.  This is a subclass of Iptables lib."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'watson@google.com (Tony Watson)'
 
 from string import Template

--- a/lib/srxlo.py
+++ b/lib/srxlo.py
@@ -19,6 +19,11 @@ uses the same syntax as regular Juniper stateless ACLs, with minor
 differences. This subclass effects those differences.
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from lib import juniper
 
 __author__ = 'vklimovs@google.com (Vjaceslavs Klimovs)'

--- a/lib/summarizer.py
+++ b/lib/summarizer.py
@@ -14,6 +14,11 @@
 
 """Discontinuous subnet mask summarizer."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'vklimovs@google.com (Vjaceslavs Klimovs)'
 
 import collections

--- a/lib/windows.py
+++ b/lib/windows.py
@@ -14,6 +14,11 @@
 
 """Generic Windows security policy generator; requires subclassing."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import datetime
 from string import Template
 

--- a/lib/windows_advfirewall.py
+++ b/lib/windows_advfirewall.py
@@ -13,6 +13,11 @@
 #
 """Windows advfirewall policy generator."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 # pylint: disable=g-importing-member
 from string import Template
 

--- a/lib/windows_ipsec.py
+++ b/lib/windows_ipsec.py
@@ -13,6 +13,11 @@
 #
 """Windows IP security policy generator."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 # pylint: disable=g-importing-member
 from string import Template
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import os
 from setuptools import setup, find_packages
 

--- a/tests/integration/aclgen_test.py
+++ b/tests/integration/aclgen_test.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from cStringIO import StringIO
 import filecmp
 import logging

--- a/tests/lib/aclcheck_test.py
+++ b/tests/lib/aclcheck_test.py
@@ -14,6 +14,11 @@
 
 """Unit tests for AclCheck."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'watson@google.com (Tony Watson)'
 
 import unittest

--- a/tests/lib/aclgenerator_test.py
+++ b/tests/lib/aclgenerator_test.py
@@ -14,6 +14,11 @@
 
 """Unittest for ACL rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import unittest
 
 from lib import aclgenerator

--- a/tests/lib/arista_test.py
+++ b/tests/lib/arista_test.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 """Tests for arista acl rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import unittest
 
 from lib import arista

--- a/tests/lib/aruba_test.py
+++ b/tests/lib/aruba_test.py
@@ -14,6 +14,11 @@
 
 """Unittest for Aruba acl rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import unittest
 
 from lib import aruba

--- a/tests/lib/brocade_test.py
+++ b/tests/lib/brocade_test.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 """Tests for brocade acl rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import re
 import unittest
 

--- a/tests/lib/cgrep_test.py
+++ b/tests/lib/cgrep_test.py
@@ -18,6 +18,11 @@
    actual and expected results are sorted/sets to prevent issues relating to the
    order in which items are returned."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import unittest
 import argparse
 from lib import naming

--- a/tests/lib/cisco_test.py
+++ b/tests/lib/cisco_test.py
@@ -14,6 +14,11 @@
 
 """Unittest for cisco acl rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import datetime
 import re
 import unittest
@@ -661,7 +666,7 @@ class CiscoTest(unittest.TestCase):
 
     mock_debug.assert_called_once_with(
         'Term good-term-11 will not be rendered,'
-        ' as it has [\'icmpv6\'] match specified but '
+        ' as it has [u\'icmpv6\'] match specified but '
         'the ACL is of inet address family.')
 
   @mock.patch.object(cisco.logging, 'debug')
@@ -673,7 +678,7 @@ class CiscoTest(unittest.TestCase):
 
     mock_debug.assert_called_once_with(
         'Term good-term-1 will not be rendered,'
-        ' as it has [\'icmp\'] match specified but '
+        ' as it has [u\'icmp\'] match specified but '
         'the ACL is of inet6 address family.')
 
   def testUnsupportedKeywordsError(self):

--- a/tests/lib/ciscoasa_test.py
+++ b/tests/lib/ciscoasa_test.py
@@ -14,6 +14,11 @@
 
 """Unittest for ciscoasa acl rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import unittest
 
 from lib import ciscoasa

--- a/tests/lib/ciscoxr_test.py
+++ b/tests/lib/ciscoxr_test.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 """Unittest for Cisco XR acl rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import unittest
 
 from lib import ciscoxr

--- a/tests/lib/gce_test.py
+++ b/tests/lib/gce_test.py
@@ -14,6 +14,11 @@
 
 """Unittest for GCE firewall rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import json
 import unittest
 

--- a/tests/lib/ipset_test.py
+++ b/tests/lib/ipset_test.py
@@ -14,6 +14,11 @@
 
 """Unittest for Ipset rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import unittest
 
 from lib import ipset

--- a/tests/lib/iptables_test.py
+++ b/tests/lib/iptables_test.py
@@ -14,6 +14,11 @@
 
 """Unittest for iptables rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import datetime
 import re
 import unittest
@@ -1109,7 +1114,7 @@ class AclCheckTest(unittest.TestCase):
 
     mock_debug.assert_called_once_with(
         'Term inet6-icmp will not be rendered,'
-        ' as it has [\'icmpv6\'] match specified but '
+        ' as it has [u\'icmpv6\'] match specified but '
         'the ACL is of inet address family.')
 
   @mock.patch.object(iptables.logging, 'debug')
@@ -1122,7 +1127,7 @@ class AclCheckTest(unittest.TestCase):
 
     mock_debug.assert_called_once_with(
         'Term good-term-1 will not be rendered,'
-        ' as it has [\'icmp\'] match specified but '
+        ' as it has [u\'icmp\'] match specified but '
         'the ACL is of inet6 address family.')
 
   def testOwner(self):

--- a/tests/lib/juniper_test.py
+++ b/tests/lib/juniper_test.py
@@ -14,6 +14,11 @@
 
 """Unittest for juniper acl rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import datetime
 import re
 import unittest
@@ -947,7 +952,7 @@ class JuniperTest(unittest.TestCase):
 
     mock_debug.assert_called_once_with(
         'Term icmptype-mismatch will not be rendered,'
-        ' as it has [\'icmpv6\'] match specified but '
+        ' as it has [u\'icmpv6\'] match specified but '
         'the ACL is of inet address family.')
 
   @mock.patch.object(juniper.logging, 'debug')
@@ -960,7 +965,7 @@ class JuniperTest(unittest.TestCase):
 
     mock_debug.assert_called_once_with(
             'Term icmptype-mismatch will not be rendered,'
-            ' as it has [\'icmp\'] match specified but '
+            ' as it has [u\'icmp\'] match specified but '
             'the ACL is of inet6 address family.')
 
   @mock.patch.object(juniper.logging, 'warn')

--- a/tests/lib/junipersrx_test.py
+++ b/tests/lib/junipersrx_test.py
@@ -14,6 +14,11 @@
 
 """Unit test for Juniper SRX acl rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import copy
 import datetime
 import unittest

--- a/tests/lib/nacaddr_test.py
+++ b/tests/lib/nacaddr_test.py
@@ -14,6 +14,11 @@
 
 """Unittest for nacaddr.py module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'watson@google.com (Tony Watson)'
 
 import unittest

--- a/tests/lib/naming_test.py
+++ b/tests/lib/naming_test.py
@@ -14,6 +14,11 @@
 
 """Unittest for naming.py module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'watson@google.com (Tony Watson)'
 
 import io
@@ -159,13 +164,13 @@ class NamingUnitTest(unittest.TestCase):
 
   def testParseNetFile(self):
     filedefs = naming.Naming(None)
-    data = io.BytesIO('FOO = 127.0.0.1 # some network\n')
+    data = io.BytesIO('FOO = 127.0.0.1 # some network\n'.encode('utf8'))
     filedefs._ParseFile(data, 'networks')
     self.assertEqual(filedefs.GetNetAddr('FOO'), [nacaddr.IPv4('127.0.0.1')])
 
   def testParseServiceFile(self):
     filedefs = naming.Naming(None)
-    data = io.BytesIO('HTTP = 80/tcp\n')
+    data = io.BytesIO('HTTP = 80/tcp\n'.encode('utf8'))
     filedefs._ParseFile(data, 'services')
     self.assertEqual(filedefs.GetService('HTTP'), ['80/tcp'])
 

--- a/tests/lib/nftables_test.py
+++ b/tests/lib/nftables_test.py
@@ -14,6 +14,11 @@
 
 """Unittest for Nftables rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import datetime
 import unittest
 
@@ -325,7 +330,7 @@ class NftablesTest(unittest.TestCase):
                                              self.mock_naming), EXP_INFO))
     mock_logging_debug.assert_called_once_with('Term inet6-icmp will not be '
                                                'rendered, as it has '
-                                               '[\'icmpv6\'] match specified '
+                                               '[u\'icmpv6\'] match specified '
                                                'but the ACL is of inet address '
                                                'family.')
 

--- a/tests/lib/nsxv_functtest.py
+++ b/tests/lib/nsxv_functtest.py
@@ -14,6 +14,10 @@
 #
 """Functional test class for nsxv.py"""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import unittest
 # system imports

--- a/tests/lib/nsxv_mocktest.py
+++ b/tests/lib/nsxv_mocktest.py
@@ -14,6 +14,11 @@
 #
 """Nsxv Mock Test terms for nsxv.py"""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 
 INET_TERM="""\
   term permit-mail-services {

--- a/tests/lib/nsxv_test.py
+++ b/tests/lib/nsxv_test.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 """UnitTest class for nsxv.py."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import unittest
 from xml.etree import ElementTree as ET
 

--- a/tests/lib/nsxv_unittest.py
+++ b/tests/lib/nsxv_unittest.py
@@ -14,6 +14,11 @@
 #
 """UnitTest class for nsxv.py"""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 
 import unittest
 from xml.etree import ElementTree as ET

--- a/tests/lib/packetfilter_test.py
+++ b/tests/lib/packetfilter_test.py
@@ -14,6 +14,11 @@
 
 """Unittest for packetfilter rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import datetime
 import unittest
 

--- a/tests/lib/pcap_test.py
+++ b/tests/lib/pcap_test.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 """Unittest for pcap rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import datetime
 import unittest
 

--- a/tests/lib/policy_simple_test.py
+++ b/tests/lib/policy_simple_test.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import unittest
 
 from lib import policy_simple

--- a/tests/lib/policy_test.py
+++ b/tests/lib/policy_test.py
@@ -14,6 +14,11 @@
 
 """Unit tests for policy.py library."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'watson@google.com (Tony Watson)'
 
 import unittest

--- a/tests/lib/speedway_test.py
+++ b/tests/lib/speedway_test.py
@@ -14,6 +14,11 @@
 
 """Unittest for Speedway rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import unittest
 
 

--- a/tests/lib/srxlo_test.py
+++ b/tests/lib/srxlo_test.py
@@ -14,6 +14,11 @@
 
 """Unittest for Srxlo rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import unittest
 
 

--- a/tests/lib/summarizer_test.py
+++ b/tests/lib/summarizer_test.py
@@ -14,6 +14,11 @@
 
 """Tests for discontinuous subnet mask summarizer."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __author__ = 'vklimovs@google.com (Vjaceslavs Klimovs)'
 
 import os

--- a/tests/lib/windows_advfirewall_test.py
+++ b/tests/lib/windows_advfirewall_test.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 """Unittest for windows_advfirewall rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import datetime
 import unittest
 

--- a/tests/lib/windows_ipsec_test.py
+++ b/tests/lib/windows_ipsec_test.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 """Unittest for windows_ipsec rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import datetime
 import unittest
 

--- a/tests/lib/windows_test.py
+++ b/tests/lib/windows_test.py
@@ -14,6 +14,11 @@
 
 """Unittest for windows acl rendering module."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import unittest
 
 from lib import naming


### PR DESCRIPTION
Summary:

I'd like to add these future imports to all of the python code.
This will allow us to write python3 compatible code more easily, with the
eventualy hope that we can support python3 in the future.  The last big
hold out for not doing this was python-gflags not supporting python3. That
changed sometime last month so i'd like to get us moving in that direction.
The end is near.  https://pythonclock.org/

The harder part of this effort revolves around nacaddr.  We've solved this
once internally, but it could use some more work.  That effort will be in
later PR requests.

Test Plan: python2.7 -m unittest discover -p *_test.py

......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 518 tests in 82.943s

OK