### PR TITLE
add flexible-match-range functionality to juniper platform

### DIFF
--- a/lib/juniper.py
+++ b/lib/juniper.py
@@ -276,6 +276,7 @@ class Term(aclgenerator.Term):
                           self.term.destination_port or
                           self.term.destination_prefix or
                           self.term.ether_type or
+                          self.term.flexible_match_range or
                           self.term.forwarding_class or
                           self.term.hop_limit or
                           self.term.next_ip or
@@ -489,6 +490,13 @@ class Term(aclgenerator.Term):
         # Only generate a hop-limit if inet6, inet4 has not hop-limit.
         if self.term_type == 'inet6':
           config.Append('hop-limit %s;' % (self.term.hop_limit))
+
+      # flexible-match
+      if self.term.flexible_match_range:
+        config.Append('flexible-match-range {')
+        for fm_opt in self.term.flexible_match_range:
+          config.Append('%s %s;' % (fm_opt[0], fm_opt[1]))
+        config.Append('}')
 
       config.Append('}')  # end from { ... }
 
@@ -776,6 +784,7 @@ class Juniper(aclgenerator.ACLGenerator):
                          'dscp_match',
                          'dscp_set',
                          'ether_type',
+                         'flexible_match_range',
                          'forwarding_class',
                          'fragment_offset',
                          'hop_limit',

--- a/lib/policy.py
+++ b/lib/policy.py
@@ -40,6 +40,14 @@ DEFINITIONS = None
 DEFAULT_DEFINITIONS = './def'
 ACTIONS = set(('accept', 'count', 'deny', 'reject', 'next',
                'reject-with-tcp-rst'))
+_FLEXIBLE_MATCH_RANGE_ATTRIBUTES = {'byte-offset',
+                                    'bit-offset',
+                                    'bit-length',
+                                    'match-start',
+                                    'range',
+                                    'range-except',
+                                    'flexible-range-name'}
+_FLEXIBLE_MATCH_START_OPTIONS = {'layer-3', 'layer-4', 'payload'}
 _LOGGING = set(('true', 'True', 'syslog', 'local', 'disable', 'log-both'))
 _OPTIMIZE = True
 _SHADE_CHECK = False
@@ -107,6 +115,10 @@ class NoTermsError(Error):
 
 class ShadingError(Error):
   """Error when a term is shaded by a prior term."""
+
+
+class FlexibleMatchError(Error):
+  """Error when a term contains an invalid flexible match value."""
 
 
 def TranslatePorts(ports, protocols, term_name):
@@ -290,6 +302,7 @@ class Term(object):
     dscp-match: VarType.DSCP_MATCH
     dscp-except: VarType.DSCP_EXCEPT
     comments: VarType.COMMENT
+    flexible-match-range: VarType.FLEXIBLE_MATCH_RANGE
     forwarding-class: VarType.FORWARDING_CLASS
     expiration: VarType.EXPIRATION
     verbatim: VarType.VERBATIM
@@ -397,6 +410,7 @@ class Term(object):
     self.dscp_match = []
     self.dscp_except = []
     self.next_ip = None
+    self.flexible_match_range = []
     # srx specific
     self.vpn = None
     # gce specific
@@ -637,6 +651,8 @@ class Term(object):
       ret_str.append('  action: %s' % self.action)
     if self.option:
       ret_str.append('  option: %s' % self.option)
+    if self.flexible_match_range:
+      ret_str.append('  flexible_match_range: %s' % self.flexible_match_range)
     if self.qos:
       ret_str.append('  qos: %s' % self.qos)
     if self.logging:
@@ -771,6 +787,10 @@ class Term(object):
 
     # next_ip
     if self.next_ip != other.next_ip:
+      return False
+
+    # flexible_match
+    if self.flexible_match_range != other.flexible_match_range:
       return False
 
     return True
@@ -959,6 +979,8 @@ class Term(object):
           self.source_tag.append(x.value)
         elif x.var_type is VarType.DTAG:
           self.destination_tag.append(x.value)
+        elif x.var_type is VarType.FLEXIBLE_MATCH_RANGE:
+          self.flexible_match_range.append(x.value)
         else:
           raise TermObjectTypeError(
               '%s isn\'t a type I know how to deal with (contains \'%s\')' % (
@@ -1311,6 +1333,7 @@ class VarType(object):
   NEXT_IP = 46
   HOP_LIMIT = 47
   LOG_NAME = 48
+  FLEXIBLE_MATCH_RANGE = 49
 
   def __init__(self, var_type, value):
     self.var_type = var_type
@@ -1490,12 +1513,14 @@ tokens = (
     'ESCAPEDSTRING',
     'ETHER_TYPE',
     'EXPIRATION',
+    'FLEXIBLE_MATCH_RANGE',
     'FORWARDING_CLASS',
     'FRAGMENT_OFFSET',
     'HOP_LIMIT',
     'APPLY_GROUPS',
     'APPLY_GROUPS_EXCEPT',
     'HEADER',
+    'HEX',
     'ICMP_TYPE',
     'INTEGER',
     'LOGGING',
@@ -1550,8 +1575,10 @@ reserved = {
     'dscp-set': 'DSCP_SET',
     'ether-type': 'ETHER_TYPE',
     'expiration': 'EXPIRATION',
+    'flexible-match-range': 'FLEXIBLE_MATCH_RANGE',
     'forwarding-class': 'FORWARDING_CLASS',
     'fragment-offset': 'FRAGMENT_OFFSET',
+    'hex': 'HEX',
     'hop-limit': 'HOP_LIMIT',
     'apply-groups': 'APPLY_GROUPS',
     'apply-groups-except': 'APPLY_GROUPS_EXCEPT',
@@ -1636,6 +1663,11 @@ def t_DSCP(t):
   return t
 
 
+def t_HEX(t):
+  r'0x[a-fA-F0-9]+'
+  return t
+
+
 def t_INTEGER(t):
   r'\d+'
   return t
@@ -1712,6 +1744,7 @@ def p_term_spec(p):
                 | term_spec ether_type_spec
                 | term_spec exclude_spec
                 | term_spec expiration_spec
+                | term_spec flexible_match_range_spec
                 | term_spec forwarding_class_spec
                 | term_spec fragment_offset_spec
                 | term_spec hop_limit_spec
@@ -1760,6 +1793,48 @@ def p_losspriority_spec(p):
 def p_precedence_spec(p):
   """ precedence_spec : PRECEDENCE ':' ':' one_or_more_ints """
   p[0] = VarType(VarType.PRECEDENCE, p[4])
+
+
+def p_flexible_match_range_spec(p):
+  """ flexible_match_range_spec : FLEXIBLE_MATCH_RANGE ':' ':' flex_match_key_values """
+  p[0] = []
+  for kv in p[4]:
+    p[0].append(VarType(VarType.FLEXIBLE_MATCH_RANGE, kv))
+
+
+def p_flex_match_key_values(p):
+  """ flex_match_key_values : flex_match_key_values STRING HEX
+                            | flex_match_key_values STRING INTEGER
+                            | flex_match_key_values STRING STRING
+                            | STRING HEX
+                            | STRING INTEGER
+                            | STRING STRING
+                            | """
+  if len(p) < 1:
+    return
+
+  if p[1] not in _FLEXIBLE_MATCH_RANGE_ATTRIBUTES:
+    raise FlexibleMatchError('%s is not a valid attribute' % p[1])
+  if p[1] == 'match-start':
+    if p[2] not in _FLEXIBLE_MATCH_START_OPTIONS:
+      raise FlexibleMatchError('%s value is not valid' % p[1])
+  # per Juniper, max bit length is 32
+  elif p[1] == 'bit-length':
+    if int(p[2]) not in range(33):
+      raise FlexibleMatchError('%s value is not valid' % p[1])
+  # per Juniper, max bit offset is 7
+  elif p[1] == 'bit-offset':
+    if int(p[2]) not in range(8):
+      raise FlexibleMatchError('%s value is not valid' % p[1])
+  # per Juniper, offset can be up to 256 bytes
+  elif p[1] == 'byte-offset':
+    if int(p[2]) not in range(256):
+      raise FlexibleMatchError('%s value is not valid' % p[1])
+
+  if type(p[0]) == type([]):
+    p[0].append(p[1:])
+  else:
+    p[0] = [p[1:]]
 
 
 def p_forwarding_class_spec(p):

--- a/lib/srxlo.py
+++ b/lib/srxlo.py
@@ -13,6 +13,7 @@
 #
 
 """Juniper SRX generator for loopback ACLs.
+
 This is a subclass of Juniper generator. Juniper SRX loopback filter
 uses the same syntax as regular Juniper stateless ACLs, with minor
 differences. This subclass effects those differences.
@@ -48,3 +49,15 @@ class SRXlo(juniper.Juniper):
   _PLATFORM = 'srxlo'
   SUFFIX = '.jsl'
   _TERM = Term
+
+  def _BuildTokens(self):
+    """Build supported tokens for platform.
+
+    Returns:
+      tuple containing both supported tokens and sub tokens
+    """
+    supported_tokens, supported_sub_tokens = super(SRXlo, self)._BuildTokens()
+    # flexible match is MX/Trio only
+    supported_tokens.remove('flexible_match_range')
+
+    return supported_tokens, supported_sub_tokens

--- a/tests/lib/juniper_test.py
+++ b/tests/lib/juniper_test.py
@@ -396,6 +396,61 @@ term good-term-1 {
   action:: accept
 }
 """
+GOOD_FLEX_MATCH_TERM = """
+term flex-match-term-1 {
+  protocol:: tcp
+  flexible-match-range:: bit-length 8
+  flexible-match-range:: range 0x08
+  flexible-match-range:: match-start payload
+  flexible-match-range:: byte-offset 16
+  flexible-match-range:: bit-offset 7
+  action:: deny
+}
+"""
+BAD_FLEX_MATCH_TERM_1 = """
+term flex-match-term-1 {
+  protocol:: tcp
+  flexible-match-range:: bit-length 36
+  flexible-match-range:: range 0x08
+  flexible-match-range:: match-start payload
+  flexible-match-range:: byte-offset 16
+  flexible-match-range:: bit-offset 7
+  action:: deny
+}
+"""
+BAD_FLEX_MATCH_TERM_2 = """
+term flex-match-term-1 {
+  protocol:: tcp
+  flexible-match-range:: bit-length 8
+  flexible-match-range:: range 0x08
+  flexible-match-range:: match-start wrong
+  flexible-match-range:: byte-offset 16
+  flexible-match-range:: bit-offset 7
+  action:: deny
+}
+"""
+BAD_FLEX_MATCH_TERM_3 = """
+term flex-match-term-1 {
+  protocol:: tcp
+  flexible-match-range:: bit-length 8
+  flexible-match-range:: range 0x08
+  flexible-match-range:: match-start payload
+  flexible-match-range:: byte-offset 260
+  flexible-match-range:: bit-offset 7
+  action:: deny
+}
+"""
+BAD_FLEX_MATCH_TERM_4 = """
+term flex-match-term-1 {
+  protocol:: tcp
+  flexible-match-range:: bit-length 8
+  flexible-match-range:: range 0x08
+  flexible-match-range:: match-start payload
+  flexible-match-range:: byte-offset 16
+  flexible-match-range:: bit-offset 8
+  action:: deny
+}
+"""
 
 SUPPORTED_TOKENS = {
     'action',
@@ -411,6 +466,7 @@ SUPPORTED_TOKENS = {
     'dscp_set',
     'ether_type',
     'expiration',
+    'flexible_match_range',
     'forwarding_class',
     'fragment_offset',
     'hop_limit',
@@ -1175,6 +1231,82 @@ class JuniperTest(unittest.TestCase):
                                              self.naming), EXP_INFO)
     output = str(jcl)
     self.failUnless('protocol hop-by-hop;' in output, output)
+
+  def testFlexibleMatch(self):
+    jcl = juniper.Juniper(policy.ParsePolicy(
+        GOOD_HEADER + GOOD_FLEX_MATCH_TERM, self.naming), EXP_INFO)
+
+    output = str(jcl)
+
+    flexible_match_expected = [
+        'flexible-match-range {',
+        'bit-length 8;',
+        'range 0x08;',
+        'match-start payload;',
+        'byte-offset 16;',
+        'bit-offset 7;'
+    ]
+
+    self.assertEquals(all([x in output for x in flexible_match_expected]), True)
+
+  def testFlexibleMatchIPv6(self):
+    jcl = juniper.Juniper(policy.ParsePolicy(
+        GOOD_HEADER_V6 + GOOD_FLEX_MATCH_TERM, self.naming), EXP_INFO)
+    output = str(jcl)
+
+    flexible_match_expected = [
+        'flexible-match-range {',
+        'bit-length 8;',
+        'range 0x08;',
+        'match-start payload;',
+        'byte-offset 16;',
+        'bit-offset 7;'
+    ]
+
+    self.assertEquals(all([x in output for x in flexible_match_expected]), True)
+
+  def testFailFlexibleMatch(self):
+
+    # bad bit-length
+    self.assertRaises(policy.FlexibleMatchError,
+                      policy.ParsePolicy,
+                      GOOD_HEADER + BAD_FLEX_MATCH_TERM_1,
+                      self.naming)
+    self.assertRaises(policy.FlexibleMatchError,
+                      policy.ParsePolicy,
+                      GOOD_HEADER_V6 + BAD_FLEX_MATCH_TERM_1,
+                      self.naming)
+
+    # bad match-start
+    self.assertRaises(policy.FlexibleMatchError,
+                      policy.ParsePolicy,
+                      GOOD_HEADER + BAD_FLEX_MATCH_TERM_2,
+                      self.naming)
+    self.assertRaises(policy.FlexibleMatchError,
+                      policy.ParsePolicy,
+                      GOOD_HEADER_V6 + BAD_FLEX_MATCH_TERM_2,
+                      self.naming)
+
+    # bad byte-offset
+    self.assertRaises(policy.FlexibleMatchError,
+                      policy.ParsePolicy,
+                      GOOD_HEADER + BAD_FLEX_MATCH_TERM_3,
+                      self.naming)
+    self.assertRaises(policy.FlexibleMatchError,
+                      policy.ParsePolicy,
+                      GOOD_HEADER_V6 + BAD_FLEX_MATCH_TERM_3,
+                      self.naming)
+
+    # bad bit-offset
+    self.assertRaises(policy.FlexibleMatchError,
+                      policy.ParsePolicy,
+                      GOOD_HEADER + BAD_FLEX_MATCH_TERM_4,
+                      self.naming)
+    self.assertRaises(policy.FlexibleMatchError,
+                      policy.ParsePolicy,
+                      GOOD_HEADER_V6 + BAD_FLEX_MATCH_TERM_4,
+                      self.naming)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Starting in JUNOS 14, Trio line cards for MX routers now support 'flexible match' which is a very powerful DPI-like capability that allows you to match on a packets' headers or content using byte & bit offsets and hex or binary patterns. This can then be used to combat known attack signatures on a router at near line-rate.
This PR is specific to flexible-match-range; I will probably get working on the other flexible match variant (flexible-match-mask) later this month.

Usage example:
```
term flex-match-term-1 {
  protocol:: tcp
  flexible-match-range:: bit-length 8
  flexible-match-range:: range 0x08
  flexible-match-range:: match-start payload
  flexible-match-range:: byte-offset 16
  flexible-match-range:: bit-offset 7
  action:: deny
}
```