### PR TITLE
requirements: Use python-gflags 3.0 or higher

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 PyYAML==3.11
 ipaddr
-python-gflags
+python-gflags>=3.0
 ply
 mock
 six # requirement from gflags


### PR DESCRIPTION
* After patch 0ae35f5 newer python-gflags now required,
otherwise you will encounter "gflags.FlagsError: Flag name must be a
string"

Signed-off-by: Misha Komarovskiy <zombah@gmail.com>