### PR TITLE
Nsxv plugin Enhancements

### DIFF
--- a/doc/policy_format.txt
+++ b/doc/policy_format.txt
@@ -92,11 +92,14 @@ nostate: specifies to produce 'stateless' filter output (e.g. no connection trac
 NSX
 
 The nsx header designation has the following format:
-target:: nsxv {inet|inet6|mixed} [section-id]
+target:: nsxv {inet|inet6|mixed} section-id securitygroup securitygroupId
 
 inet: specifies that the resulting filter should only render IPv4 addresses.
 inet6: specifies that the resulting filter should only render IPv6 addresses.
 mixed: specifies that the resulting filter should render both IPv4 and IPv6 addresses.
+sectionId: specifies the Id for the section [optional]
+securitygroup: specifies that the appliedTo should be security group [optional]
+securitygroupId: specifies the Id of the security group [mandatory if securitygroup is given]
 (Required keywords option and verbatim are not supported in NSX)
 
 

--- a/lib/nsxv.py
+++ b/lib/nsxv.py
@@ -334,8 +334,8 @@ class Term(aclgenerator.Term):
     if self.applied_to:
       applied_to_list = '<appliedToList>'
       applied_to_element = '%s%s%s' % (_XML_TABLE.get('appliedToStart'),
-                              self.applied_to,
-                              _XML_TABLE.get('appliedToEnd'))
+                                       self.applied_to,
+                                       _XML_TABLE.get('appliedToEnd'))
       applied_to_list = '%s%s' %(applied_to_list, applied_to_element)
       applied_to_list = '%s%s' %(applied_to_list, '</appliedToList>')
 

--- a/lib/nsxv.py
+++ b/lib/nsxv.py
@@ -45,6 +45,8 @@ _XML_TABLE = {
     'protocolEnd': '</protocol>',
     'serviceStart': '<service>',
     'serviceEnd': '</service>',
+    'appliedToStart': '<appliedTo><type>SecurityGroup</type><value>',
+    'appliedToEnd': '</value></appliedTo>',
     'srcPortStart': '<sourcePort>',
     'srcPortEnd': '</sourcePort>',
     'destPortStart': '<destinationPort>',
@@ -107,12 +109,13 @@ class NsxvDuplicateTermError(Error):
 class Term(aclgenerator.Term):
   """Creates a  single ACL Term for Nsxv."""
 
-  def __init__(self, term, filter_type, af=4):
+  def __init__(self, term, filter_type, applied_to=None, af=4):
     self.term = term
     # Our caller should have already verified the address family.
     assert af in (4, 6)
     self.af = af
     self.filter_type = filter_type
+    self.applied_to = applied_to
 
   def __str__(self):
     """Convert term to a rule string.
@@ -326,14 +329,25 @@ class Term(aclgenerator.Term):
     for s in services:
       service = '%s%s' % (service, s)
 
+    #applied To
+    appliedToList = ''
+    if self.applied_to:
+      appliedToList = '<appliedToList>'
+      appliedTo = '%s%s%s' % (_XML_TABLE.get('appliedToStart'),
+                              self.applied_to,
+                              _XML_TABLE.get('appliedToEnd'))
+      appliedToList = '%s%s' %(appliedToList, appliedTo)
+      appliedToList = '%s%s' %(appliedToList, '</appliedToList>')
+
+
     # action
     action = '%s%s%s' % (_XML_TABLE.get('actionStart'),
                          _ACTION_TABLE.get(str(self.term.action[0])),
                          _XML_TABLE.get('actionEnd'))
 
     ret_lines = []
-    ret_lines.append('<rule logged="%s"> %s %s %s %s %s %s </rule>' %
-                     (log, name, action, sources, destinations, service, notes))
+    ret_lines.append('<rule logged="%s"> %s %s %s %s %s %s %s </rule>' %
+                     (log, name, action, sources, destinations, service, appliedToList, notes))
 
     # remove any trailing spaces and replace multiple spaces with singles
     stripped_ret_lines = [re.sub(r'\s+', ' ', x).rstrip() for x in ret_lines]
@@ -352,8 +366,6 @@ class Term(aclgenerator.Term):
     Returns:
       Service definition.
 
-    Raises:
-      UnsupportedNsxvAccessListError: When unknown icmp-types specified
     """
     service = ''
     # for icmp and icmpv6
@@ -447,9 +459,6 @@ class Nsxv(aclgenerator.ACLGenerator):
     current_date = datetime.datetime.utcnow().date()
     exp_info_date = current_date + datetime.timedelta(weeks=exp_info)
 
-    # a mixed filter outputs both ipv4 and ipv6 acls in the same output file
-    good_filters = ['inet', 'inet6', 'mixed']
-
     for header, terms in pol.filters:
       if self._PLATFORM not in header.platforms:
         continue
@@ -457,19 +466,12 @@ class Nsxv(aclgenerator.ACLGenerator):
       filter_options = header.FilterOptions(self._PLATFORM)
       filter_name = header.FilterName(self._PLATFORM)
 
-      # check for filter type
-      filter_type = ''
-      if filter_options is not None and filter_options > 0:
-        filter_type = filter_options[0]
-      else:
-        raise UnsupportedNsxvAccessListError(
-            'Filter type is not provided for %s'  % (self._PLATFORM))
+      # get filter type, section id and applied To
+      filter_dict = self._ParseFilterOptions(filter_options)
 
-      # check if filter type is renderable
-      if filter_type not in good_filters:
-        raise UnsupportedNsxvAccessListError(
-            'access list type %s not supported by %s (good types: %s)' % (
-                filter_type, self._PLATFORM, str(good_filters)))
+      filter_type = filter_dict['filter_type']
+      section_id = filter_dict['section_id']
+      applied_to = filter_dict['applied_to']
 
       term_names = set()
       new_terms = []
@@ -503,29 +505,82 @@ class Nsxv(aclgenerator.ACLGenerator):
           term = self.FixHighPorts(term, af=af)
           if not term:
             continue
-          new_terms.append(Term(term, filter_type, 4))
+          new_terms.append(Term(term, filter_type, applied_to, 4))
 
         if filter_type == 'inet6':
           af = 'inet6'
           term = self.FixHighPorts(term, af=af)
           if not term:
             continue
-          new_terms.append(Term(term, filter_type, 6))
+          new_terms.append(Term(term, filter_type, applied_to, 6))
 
         if filter_type == 'mixed':
           if 'icmpv6' not in term.protocol:
             inet_term = self.FixHighPorts(term, 'inet')
             if not inet_term:
               continue
-            new_terms.append(Term(inet_term, filter_type, 4))
+            new_terms.append(Term(inet_term, filter_type, applied_to, 4))
           else:
             inet6_term = self.FixHighPorts(term, 'inet6')
             if not inet6_term:
               continue
-            new_terms.append(Term(inet6_term, filter_type, 6))
+            new_terms.append(Term(inet6_term, filter_type, applied_to, 6))
 
-      self.nsxv_policies.append((header, filter_name, [filter_type],
+      self.nsxv_policies.append((header, filter_name, [filter_type], section_id,
                                  new_terms))
+
+  def _ParseFilterOptions(self, filter_options):
+    """Parses the target in header for filter type, section_id and applied_to.
+       target:: nsxv mixed 12345 securitygroup securitygroupId
+       filter_options : [mixed, sectionid, securitygroup, securitygroupId]
+
+       section id is optional
+       SecurityGroup securitygroupId is also optional
+
+       The element followed by 'securitygroup' is the securitygroupId.
+    """
+    filter_options_dict = {}
+
+    # check for filter type
+    if not filter_options:
+      raise UnsupportedNsxvAccessListError(
+        'Filter type is not provided for %s'  % (self._PLATFORM))
+
+    if len(filter_options) > 4:
+      raise UnsupportedNsxvAccessListError('Too many target options.')
+
+    # mandatory
+    filter_type = filter_options[0]
+
+    # a mixed filter outputs both ipv4 and ipv6 acls in the same output file
+    good_filters = ['inet', 'inet6', 'mixed']
+
+    # check if filter type is renderable
+    if filter_type not in good_filters:
+      raise UnsupportedNsxvAccessListError(
+          'Access list type %s not supported by %s (good types: %s)' % (
+             filter_type, self._PLATFORM, str(good_filters)))
+
+    section_id = 0
+    applied_to = None
+    filter_opt_len = len(filter_options)
+
+    if filter_opt_len > 1:
+      for index in range(1, filter_opt_len):
+        if index == 1 and filter_options[1] != 'securitygroup':
+          section_id = filter_options[1]
+          continue
+        if (filter_options[index] == 'securitygroup'):
+          if (index + 1 <= filter_opt_len - 1):
+            applied_to = filter_options[index + 1]
+            break
+          else:
+            raise UnsupportedNsxvAccessListError('Security Group Id is not provided for %s' % (self._PLATFORM))
+
+    filter_options_dict['filter_type'] = filter_type
+    filter_options_dict['section_id'] = section_id
+    filter_options_dict['applied_to'] = applied_to
+    return filter_options_dict
 
   def __str__(self):
     """Render the output of the Nsxv policy."""
@@ -538,18 +593,12 @@ class Nsxv(aclgenerator.ACLGenerator):
     target.extend(aclgenerator.AddRepositoryTags(' '))
     target.append('-->')
 
-    for (header, _, _, terms) in self.nsxv_policies:
+    for (header, _, _, section_id, terms) in self.nsxv_policies:
       # add a header comment if one exists
       section_name = ''
       for comment in header.comment:
         for line in comment.split('\n'):
           section_name = '%s %s' % (section_name, line)
-
-      # getting section id
-      filter_options = header.FilterOptions(self._PLATFORM)
-      section_id = 0
-      if filter_options is not None and len(filter_options) > 1:
-        section_id = filter_options[1]
 
       # check section id value
       if not section_id or section_id == 0:

--- a/policies/pol/sample_nsxv.pol
+++ b/policies/pol/sample_nsxv.pol
@@ -1,6 +1,6 @@
 header {
   comment:: "Sample NSXV filter"
-  target:: nsxv inet 1009
+  target:: nsxv mixed 1234 securitygroup securitygroupId
 }
 
 term accept-icmp {

--- a/tests/lib/nsxv_test.py
+++ b/tests/lib/nsxv_test.py
@@ -146,7 +146,7 @@ POLICY = """\
 
 POLICY_WITH_SECURITY_GROUP = """\
   header {
-    comment:: "Sample NSXV filter with Security Group"
+    comment:: "Sample filter with Security Group"
     target:: nsxv inet 1010 securitygroup securitygroup-Id
   }
 
@@ -395,7 +395,7 @@ class TermTest(unittest.TestCase):
     pol = policy.ParsePolicy(INET_FILTER, self.naming, False)
     translate_pol = nsxv.Nsxv(pol, EXP_INFO)
     nsxv_policies = translate_pol.nsxv_policies
-    for (header, filter_name, filter_list, section_id, terms) in nsxv_policies:
+    for (_, filter_name, filter_list, _, terms) in nsxv_policies:
       self.assertEqual(filter_name, 'inet')
       self.assertEqual(filter_list, ['inet'])
       self.assertEqual(len(terms), 1)
@@ -416,7 +416,7 @@ class TermTest(unittest.TestCase):
     pol = policy.ParsePolicy(INET_FILTER_WITH_ESTABLISHED, self.naming, False)
     translate_pol = nsxv.Nsxv(pol, EXP_INFO)
     nsxv_policies = translate_pol.nsxv_policies
-    for (header, filter_name, filter_list, section_id, terms) in nsxv_policies:
+    for (_, filter_name, filter_list, _, terms) in nsxv_policies:
       self.assertEqual(filter_name, 'inet')
       self.assertEqual(filter_list, ['inet'])
       self.assertEqual(len(terms), 1)
@@ -541,7 +541,7 @@ class TermTest(unittest.TestCase):
 
     root = ET.fromstring(sections[1])
     # check section name
-    section_name = {'id': '1010', 'name': 'Sample NSXV filter with Security Group'}
+    section_name = {'id': '1010', 'name': 'Sample filter with Security Group'}
     self.assertEqual(root.attrib, section_name)
     # check name and action
     self.assertEqual(root.find('./rule/name').text, 'accept-icmp')
@@ -581,21 +581,23 @@ class TermTest(unittest.TestCase):
     self.assertEquals(sst, SUPPORTED_SUB_TOKENS)
 
   def testParseFilterOptionsCase1(self):
-    pol = nsxv.Nsxv(policy.ParsePolicy(HEADER_WITH_SECTIONID + TERM, self.naming, False), EXP_INFO)
-    for (header, filter_name, filter_list, section_id, terms) in pol.nsxv_policies:
+    pol = nsxv.Nsxv(policy.ParsePolicy(HEADER_WITH_SECTIONID + TERM,
+                                       self.naming, False), EXP_INFO)
+    for (header, _, _, _, _) in pol.nsxv_policies:
       filter_options = header.FilterOptions(_PLATFORM)
       filter_options_dict = pol._ParseFilterOptions(filter_options)
-      self.assertEquals(filter_options_dict['filter_type'],'inet')
-      self.assertEquals(filter_options_dict['section_id'],'1009')
+      self.assertEquals(filter_options_dict['filter_type'], 'inet')
+      self.assertEquals(filter_options_dict['section_id'], '1009')
       self.assertEquals(filter_options_dict['applied_to'], None)
 
   def testParseFilterOptionsCase2(self):
-    pol = nsxv.Nsxv(policy.ParsePolicy(HEADER_WITH_SECURITYGROUP + INET6_TERM, self.naming, False), EXP_INFO)
-    for (header, filter_name, filter_list, section_id, terms) in pol.nsxv_policies:
+    pol = nsxv.Nsxv(policy.ParsePolicy(HEADER_WITH_SECURITYGROUP + INET6_TERM,
+                                       self.naming, False), EXP_INFO)
+    for (header, _, _, _, _) in pol.nsxv_policies:
       filter_options = header.FilterOptions(_PLATFORM)
       filter_options_dict = pol._ParseFilterOptions(filter_options)
-      self.assertEquals(filter_options_dict['filter_type'],'inet6')
-      self.assertEquals(filter_options_dict['section_id'],0)
+      self.assertEquals(filter_options_dict['filter_type'], 'inet6')
+      self.assertEquals(filter_options_dict['section_id'], 0)
       self.assertEquals(filter_options_dict['applied_to'], 'securitygroup-Id1')
 
   def testBadHeaderCase1(self):
@@ -611,7 +613,7 @@ class TermTest(unittest.TestCase):
   def testBadHeaderCase3(self):
     pol = policy.ParsePolicy(BAD_HEADER_2 + INET6_TERM, self.naming, False)
     self.assertRaises(nsxv.UnsupportedNsxvAccessListError,
-                      nsxv.Nsxv, pol, EXP_INFO )
+                      nsxv.Nsxv, pol, EXP_INFO)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/nsxv_test.py
+++ b/tests/lib/nsxv_test.py
@@ -395,7 +395,7 @@ class TermTest(unittest.TestCase):
     pol = policy.ParsePolicy(INET_FILTER, self.naming, False)
     translate_pol = nsxv.Nsxv(pol, EXP_INFO)
     nsxv_policies = translate_pol.nsxv_policies
-    for (_, filter_name, filter_list, _, terms) in nsxv_policies:
+    for (_, filter_name, filter_list, terms) in nsxv_policies:
       self.assertEqual(filter_name, 'inet')
       self.assertEqual(filter_list, ['inet'])
       self.assertEqual(len(terms), 1)
@@ -416,7 +416,7 @@ class TermTest(unittest.TestCase):
     pol = policy.ParsePolicy(INET_FILTER_WITH_ESTABLISHED, self.naming, False)
     translate_pol = nsxv.Nsxv(pol, EXP_INFO)
     nsxv_policies = translate_pol.nsxv_policies
-    for (_, filter_name, filter_list, _, terms) in nsxv_policies:
+    for (_, filter_name, filter_list, terms) in nsxv_policies:
       self.assertEqual(filter_name, 'inet')
       self.assertEqual(filter_list, ['inet'])
       self.assertEqual(len(terms), 1)
@@ -440,7 +440,7 @@ class TermTest(unittest.TestCase):
     pol = policy.ParsePolicy(INET_FILTER_WITH_ESTABLISHED, self.naming, False)
     translate_pol = nsxv.Nsxv(pol, EXP_INFO)
     nsxv_policies = translate_pol.nsxv_policies
-    for (header, filter_name, filter_list, section_id, terms) in nsxv_policies:
+    for (_, filter_name, filter_list, terms) in nsxv_policies:
       self.assertEqual(filter_name, 'inet')
       self.assertEqual(filter_list, ['inet'])
       self.assertEqual(len(terms), 1)
@@ -583,22 +583,22 @@ class TermTest(unittest.TestCase):
   def testParseFilterOptionsCase1(self):
     pol = nsxv.Nsxv(policy.ParsePolicy(HEADER_WITH_SECTIONID + TERM,
                                        self.naming, False), EXP_INFO)
-    for (header, _, _, _, _) in pol.nsxv_policies:
+    for (header, _, _, _) in pol.nsxv_policies:
       filter_options = header.FilterOptions(_PLATFORM)
-      filter_options_dict = pol._ParseFilterOptions(filter_options)
-      self.assertEquals(filter_options_dict['filter_type'], 'inet')
-      self.assertEquals(filter_options_dict['section_id'], '1009')
-      self.assertEquals(filter_options_dict['applied_to'], None)
+      pol._ParseFilterOptions(filter_options)
+      self.assertEquals(nsxv.Nsxv._FILTER_OPTIONS_DICT['filter_type'], 'inet')
+      self.assertEquals(nsxv.Nsxv._FILTER_OPTIONS_DICT['section_id'], '1009')
+      self.assertEquals(nsxv.Nsxv._FILTER_OPTIONS_DICT['applied_to'], None)
 
   def testParseFilterOptionsCase2(self):
     pol = nsxv.Nsxv(policy.ParsePolicy(HEADER_WITH_SECURITYGROUP + INET6_TERM,
                                        self.naming, False), EXP_INFO)
-    for (header, _, _, _, _) in pol.nsxv_policies:
+    for (header, _, _, _) in pol.nsxv_policies:
       filter_options = header.FilterOptions(_PLATFORM)
-      filter_options_dict = pol._ParseFilterOptions(filter_options)
-      self.assertEquals(filter_options_dict['filter_type'], 'inet6')
-      self.assertEquals(filter_options_dict['section_id'], 0)
-      self.assertEquals(filter_options_dict['applied_to'], 'securitygroup-Id1')
+      pol._ParseFilterOptions(filter_options)
+      self.assertEquals(nsxv.Nsxv._FILTER_OPTIONS_DICT['filter_type'], 'inet6')
+      self.assertEquals(nsxv.Nsxv._FILTER_OPTIONS_DICT['section_id'], 0)
+      self.assertEquals(nsxv.Nsxv._FILTER_OPTIONS_DICT['applied_to'], 'securitygroup-Id1')
 
   def testBadHeaderCase1(self):
     pol = policy.ParsePolicy(BAD_HEADER + INET6_TERM, self.naming, False)

--- a/tests/lib/nsxv_test.py
+++ b/tests/lib/nsxv_test.py
@@ -144,13 +144,57 @@ POLICY = """\
   }
   """
 
-POLICY_NO_ACTION = """\
+POLICY_WITH_SECURITY_GROUP = """\
   header {
-    comment:: "Sample NSXV filter"
-    target:: nsxv inet
+    comment:: "Sample NSXV filter with Security Group"
+    target:: nsxv inet 1010 securitygroup securitygroup-Id
   }
+
   term accept-icmp {
     protocol:: icmp
+    action:: accept
+  }
+  """
+
+HEADER_WITH_SECTIONID = """\
+  header {
+    comment:: "Sample NSXV filter1"
+    target:: nsxv inet 1009
+  }
+  """
+
+HEADER_WITH_SECURITYGROUP = """\
+  header {
+    comment:: "Sample NSXV filter2"
+    target:: nsxv inet6 securitygroup securitygroup-Id1
+  }
+  """
+
+BAD_HEADER = """\
+  header {
+    comment:: "Sample NSXV filter3"
+    target:: nsxv inet 1011 securitygroup
+  }
+  """
+
+BAD_HEADER_1 = """\
+  header {
+    comment:: "Sample NSXV filter4"
+    target:: nsxv 1012
+  }
+  """
+
+BAD_HEADER_2 = """\
+  header {
+    comment:: "Sample NSXV filter5"
+    target:: nsxv inet securitygroup
+  }
+  """
+
+TERM = """\
+  term accept-icmp {
+    protocol:: icmp
+    action:: accept
   }
   """
 
@@ -224,6 +268,10 @@ SUPPORTED_SUB_TOKENS = {
     },
 }
 
+# Print a info message when a term is set to expire in that many weeks.
+# This is normally passed from command line.
+EXP_INFO = 2
+_PLATFORM = 'nsxv'
 
 class TermTest(unittest.TestCase):
 
@@ -238,7 +286,7 @@ class TermTest(unittest.TestCase):
 
   def testInitForinet6(self):
     """Test for Term._init_."""
-    inet6_term = nsxv.Term(INET6_TERM, 'inet6', 6)
+    inet6_term = nsxv.Term(INET6_TERM, 'inet6', None, 6)
     self.assertEqual(inet6_term.af, 6)
     self.assertEqual(inet6_term.filter_type, 'inet6')
 
@@ -316,7 +364,7 @@ class TermTest(unittest.TestCase):
     af = 6
     filter_type = 'inet6'
     for _, terms in pol.filters:
-      nsxv_term = nsxv.Term(terms[0], filter_type, af)
+      nsxv_term = nsxv.Term(terms[0], filter_type, None, af)
       rule_str = nsxv.Term.__str__(nsxv_term)
 
     # parse xml rule and check if the values are correct
@@ -337,7 +385,6 @@ class TermTest(unittest.TestCase):
 
   def testTranslatePolicy(self):
     """Test for Nsxv.test_TranslatePolicy."""
-    # exp_info default is 2
     self.naming.GetNetAddr('NTP_SERVERS').AndReturn([nacaddr.IP('10.0.0.1'),
                                                      nacaddr.IP('10.0.0.2')])
     self.naming.GetNetAddr('INTERNAL').AndReturn([nacaddr.IP('10.0.0.0/8'),
@@ -345,11 +392,10 @@ class TermTest(unittest.TestCase):
                                                   nacaddr.IP('192.168.0.0/16')])
     self.naming.GetServiceByProto.return_value = ['123']
 
-    exp_info = 2
     pol = policy.ParsePolicy(INET_FILTER, self.naming, False)
-    translate_pol = nsxv.Nsxv(pol, exp_info)
+    translate_pol = nsxv.Nsxv(pol, EXP_INFO)
     nsxv_policies = translate_pol.nsxv_policies
-    for (_, filter_name, filter_list, terms) in nsxv_policies:
+    for (header, filter_name, filter_list, section_id, terms) in nsxv_policies:
       self.assertEqual(filter_name, 'inet')
       self.assertEqual(filter_list, ['inet'])
       self.assertEqual(len(terms), 1)
@@ -367,11 +413,34 @@ class TermTest(unittest.TestCase):
                                                   nacaddr.IP('192.168.0.0/16')])
     self.naming.GetServiceByProto.return_value = ['123']
 
-    exp_info = 2
     pol = policy.ParsePolicy(INET_FILTER_WITH_ESTABLISHED, self.naming, False)
-    translate_pol = nsxv.Nsxv(pol, exp_info)
+    translate_pol = nsxv.Nsxv(pol, EXP_INFO)
     nsxv_policies = translate_pol.nsxv_policies
-    for (_, filter_name, filter_list, terms) in nsxv_policies:
+    for (header, filter_name, filter_list, section_id, terms) in nsxv_policies:
+      self.assertEqual(filter_name, 'inet')
+      self.assertEqual(filter_list, ['inet'])
+      self.assertEqual(len(terms), 1)
+
+      self.assertNotIn('<sourcePort>123</sourcePort><destinationPort>123',
+                       str(terms[0]))
+
+    self.naming.GetServiceByProto.assert_has_calls(
+        [mock.call('NTP', 'udp')] * 2)
+
+  def testTranslatePolicyWithEstablished(self):
+    """Test for Nsxv.test_TranslatePolicy."""
+    # exp_info default is 2
+    self.naming.GetNetAddr('NTP_SERVERS').AndReturn([nacaddr.IP('10.0.0.1'),
+                                                     nacaddr.IP('10.0.0.2')])
+    self.naming.GetNetAddr('INTERNAL').AndReturn([nacaddr.IP('10.0.0.0/8'),
+                                                  nacaddr.IP('172.16.0.0/12'),
+                                                  nacaddr.IP('192.168.0.0/16')])
+    self.naming.GetServiceByProto.return_value = ['123']
+
+    pol = policy.ParsePolicy(INET_FILTER_WITH_ESTABLISHED, self.naming, False)
+    translate_pol = nsxv.Nsxv(pol, EXP_INFO)
+    nsxv_policies = translate_pol.nsxv_policies
+    for (header, filter_name, filter_list, section_id, terms) in nsxv_policies:
       self.assertEqual(filter_name, 'inet')
       self.assertEqual(filter_list, ['inet'])
       self.assertEqual(len(terms), 1)
@@ -384,7 +453,6 @@ class TermTest(unittest.TestCase):
 
   def testNsxvStr(self):
     """Test for Nsxv._str_."""
-    # exp_info default is 2
     self.naming.GetNetAddr('GOOGLE_DNS').AndReturn([
         nacaddr.IP('8.8.4.4'),
         nacaddr.IP('8.8.8.8'),
@@ -392,9 +460,8 @@ class TermTest(unittest.TestCase):
         nacaddr.IP('2001:4860:4860::8888')])
     self.naming.GetServiceByProto.return_value = ['53']
 
-    exp_info = 2
     pol = policy.ParsePolicy(MIXED_FILTER, self.naming, False)
-    target = nsxv.Nsxv(pol, exp_info)
+    target = nsxv.Nsxv(pol, EXP_INFO)
 
     # parse the output and seperate sections and comment
     section_tokens = str(target).split('<section')
@@ -450,6 +517,44 @@ class TermTest(unittest.TestCase):
 
     self.naming.GetServiceByProto.assert_called_once_with('DNS', 'udp')
 
+  def testNsxvStrWithSecurityGroup(self):
+    """Test for Nsxv._str_."""
+    pol = policy.ParsePolicy(POLICY_WITH_SECURITY_GROUP, self.naming, False)
+    target = nsxv.Nsxv(pol, EXP_INFO)
+
+    # parse the output and seperate sections and comment
+    section_tokens = str(target).split('<section')
+    sections = []
+
+    for sec in section_tokens:
+      section = sec.replace('id=', '<section id=')
+      sections.append(section)
+    # parse the xml
+    # Checking comment tag
+    comment = sections[0]
+    if 'Id' not in comment:
+      self.fail('Id missing in xml comment in test_nsxv_str()')
+    if 'Date' not in comment:
+      self.fail('Date missing in xml comment in test_nsxv_str()')
+    if 'Revision' not in comment:
+      self.fail('Revision missing in xml comment in test_nsxv_str()')
+
+    root = ET.fromstring(sections[1])
+    # check section name
+    section_name = {'id': '1010', 'name': 'Sample NSXV filter with Security Group'}
+    self.assertEqual(root.attrib, section_name)
+    # check name and action
+    self.assertEqual(root.find('./rule/name').text, 'accept-icmp')
+    self.assertEqual(root.find('./rule/action').text, 'allow')
+
+    # check protocol
+    protocol = int(root.find('./rule/services/service/protocol').text)
+    self.assertEqual(protocol, 1)
+
+    # check appliedTo
+    applied_to = root.find('./rule/appliedToList/appliedTo/value').text
+    self.assertEqual(applied_to, 'securitygroup-Id')
+
   def testBuildTokens(self):
     self.naming.GetNetAddr('NTP_SERVERS').AndReturn([nacaddr.IP('10.0.0.1'),
                                                      nacaddr.IP('10.0.0.2')])
@@ -475,6 +580,38 @@ class TermTest(unittest.TestCase):
     self.assertEquals(st, SUPPORTED_TOKENS)
     self.assertEquals(sst, SUPPORTED_SUB_TOKENS)
 
+  def testParseFilterOptionsCase1(self):
+    pol = nsxv.Nsxv(policy.ParsePolicy(HEADER_WITH_SECTIONID + TERM, self.naming, False), EXP_INFO)
+    for (header, filter_name, filter_list, section_id, terms) in pol.nsxv_policies:
+      filter_options = header.FilterOptions(_PLATFORM)
+      filter_options_dict = pol._ParseFilterOptions(filter_options)
+      self.assertEquals(filter_options_dict['filter_type'],'inet')
+      self.assertEquals(filter_options_dict['section_id'],'1009')
+      self.assertEquals(filter_options_dict['applied_to'], None)
+
+  def testParseFilterOptionsCase2(self):
+    pol = nsxv.Nsxv(policy.ParsePolicy(HEADER_WITH_SECURITYGROUP + INET6_TERM, self.naming, False), EXP_INFO)
+    for (header, filter_name, filter_list, section_id, terms) in pol.nsxv_policies:
+      filter_options = header.FilterOptions(_PLATFORM)
+      filter_options_dict = pol._ParseFilterOptions(filter_options)
+      self.assertEquals(filter_options_dict['filter_type'],'inet6')
+      self.assertEquals(filter_options_dict['section_id'],0)
+      self.assertEquals(filter_options_dict['applied_to'], 'securitygroup-Id1')
+
+  def testBadHeaderCase1(self):
+    pol = policy.ParsePolicy(BAD_HEADER + INET6_TERM, self.naming, False)
+    self.assertRaises(nsxv.UnsupportedNsxvAccessListError,
+                      nsxv.Nsxv, pol, EXP_INFO)
+
+  def testBadHeaderCase2(self):
+    pol = policy.ParsePolicy(BAD_HEADER_1 + TERM, self.naming, False)
+    self.assertRaises(nsxv.UnsupportedNsxvAccessListError,
+                      nsxv.Nsxv, pol, EXP_INFO)
+
+  def testBadHeaderCase3(self):
+    pol = policy.ParsePolicy(BAD_HEADER_2 + INET6_TERM, self.naming, False)
+    self.assertRaises(nsxv.UnsupportedNsxvAccessListError,
+                      nsxv.Nsxv, pol, EXP_INFO )
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
The header options for the nsx policy will support securitygroup securitygroup-id as the target options. These are optional. If these target options are given, all the rules in the section will have appliedTo as the given Security Group.
If the values are not given, the appliedTo will be default to DISTRIBUTED_FIREWALL