### PR TITLE
Fix source-exclude/destination-exclude keywords in SRX generator

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -1,0 +1,6 @@
+To run all tests from trunk:
+python -m unittest discover -s . -p '*_test.py'
+
+Specific tests:
+python -m unittest discover -s . -p 'junipersrx_test.py'
+


### PR DESCRIPTION
Fix issue where source-exclude and destination-exclude keywords 
generated unexpected output of null address book names.  In addition, 
the use of a naked *-exclude raised errors.

This change leverages the term name to create an address-book name
for the IPs resulting from excluding source or destinations.

Appropriate unit tests are also included.

Added a README in ./tests/ for reference.