### PR TITLE
Fix for DSMO error calculation

### DIFF
--- a/lib/summarizer.py
+++ b/lib/summarizer.py
@@ -184,10 +184,10 @@ def _SummarizeSameMask(nets):
       # look for pair net, but keep index handy
       for pair_net_index, pair_net in enumerate(current_nets):
         current_address, current_netmask = current_net
-        pair_address, _ = pair_net
+        pair_address, pair_netmask = pair_net
         xored_address = current_address ^ pair_address
         # check if networks have exactly one bit difference, or are "a pair"
-        if (xored_address & (xored_address - 1) == 0) and xored_address > 0:
+        if (xored_address & (xored_address - 1) == 0) and xored_address > 0 and current_netmask == pair_netmask:
           # if pair was found, remove both, add paired up network
           # to combinetons for next run and move along
           # otherwise this network can never be paired


### PR DESCRIPTION
The module **summarizer.py** has a bug in the procedure **_SummarizeSameMask**. This procedure is used for the summarization of non contiguous subnet masks. During the summarization, the networks are sorted (after converting from "dot formatted" to integer) and then they are iterated several times to summarize them. But there is an issue when this summarization is done over a network already summarized in **more** than one octet. If two octets were already summarized the algorithm is failing because it's not taken into consideration the network mask after finding those networks are contiguous. This is the fix provided. 

You can reproduce the issue if you create a simple policy file with only one term and only one object as source or destination and the following IPs inside NETWORK definition (I'm sorry I couldn't reduce the list more):

192.168.56.2/31
192.168.56.8/31
192.168.56.20/31
192.168.56.26/31
192.168.56.28/31
192.168.56.32/31
192.168.56.40/31
192.168.56.52/31
192.168.56.58/31
192.168.56.86/31
192.168.56.130/31
192.168.56.136/31
192.168.56.148/31
192.168.56.154/31
192.168.56.156/31
192.168.56.160/31
192.168.56.168/31
192.168.56.180/31
192.168.56.186/31
192.168.56.214/31
192.168.57.2/31
192.168.57.8/31
192.168.57.20/31
192.168.57.26/31
192.168.57.28/31
192.168.57.32/31
192.168.57.40/31
192.168.57.52/31
192.168.57.58/31
192.168.57.86/31
192.168.57.130/31
192.168.57.136/31
192.168.57.148/31
192.168.57.154/31
192.168.57.156/31
192.168.57.160/31
192.168.57.168/31
192.168.57.180/31
192.168.57.186/31
192.168.57.214/31
192.168.58.2/31
192.168.58.8/31
192.168.58.20/31
192.168.58.26/31
192.168.58.28/31
192.168.58.32/31
192.168.58.40/31
192.168.58.52/31
192.168.58.58/31
192.168.58.86/31
192.168.58.130/31
192.168.58.136/31
192.168.58.148/31
192.168.58.154/31
192.168.58.156/31
192.168.58.160/31
192.168.58.168/31
192.168.58.180/31
192.168.58.186/31
192.168.58.214/31
192.168.59.2/31
192.168.59.8/31
192.168.59.20/31
192.168.59.26/31
192.168.59.28/31
192.168.59.32/31
192.168.59.40/31
192.168.59.52/31
192.168.59.58/31
192.168.59.86/31
192.168.59.130/31
192.168.59.136/31
192.168.59.148/31
192.168.59.154/31
192.168.59.156/31
192.168.59.160/31
192.168.59.168/31
192.168.59.180/31
192.168.59.186/31
192.168.59.214/31