### PR TITLE
Fix for DSMO issue

### DIFF
--- a/lib/summarizer.py
+++ b/lib/summarizer.py
@@ -186,7 +186,7 @@ def _SummarizeSameMask(nets):
         current_address, current_netmask = current_net
         pair_address, pair_netmask = pair_net
         xored_address = current_address ^ pair_address
-        # check if networks have exactly one bit difference, or are "a pair"
+        # For networks with the same network mask, check if they have exactly one bit difference or they are "a pair".
         if (xored_address & (xored_address - 1) == 0) and xored_address > 0 and current_netmask == pair_netmask:
           # if pair was found, remove both, add paired up network
           # to combinetons for next run and move along

--- a/lib/summarizer.py
+++ b/lib/summarizer.py
@@ -184,10 +184,10 @@ def _SummarizeSameMask(nets):
       # look for pair net, but keep index handy
       for pair_net_index, pair_net in enumerate(current_nets):
         current_address, current_netmask = current_net
-        pair_address, _ = pair_net
+        pair_address, pair_netmask = pair_net
         xored_address = current_address ^ pair_address
         # check if networks have exactly one bit difference, or are "a pair"
-        if (xored_address & (xored_address - 1) == 0) and xored_address > 0:
+        if (xored_address & (xored_address - 1) == 0) and xored_address > 0 and current_netmask == pair_netmask:
           # if pair was found, remove both, add paired up network
           # to combinetons for next run and move along
           # otherwise this network can never be paired

--- a/lib/summarizer.py
+++ b/lib/summarizer.py
@@ -186,8 +186,11 @@ def _SummarizeSameMask(nets):
         current_address, current_netmask = current_net
         pair_address, pair_netmask = pair_net
         xored_address = current_address ^ pair_address
-        # For networks with the same network mask, check if they have exactly one bit difference or they are "a pair".
-        if (xored_address & (xored_address - 1) == 0) and xored_address > 0 and current_netmask == pair_netmask:
+        # For networks with the same network mask:
+        # check if they have exactly one bit difference
+        # or they are "a pair".
+        if (current_netmask == pair_netmask and
+            (xored_address & (xored_address - 1) == 0) and xored_address > 0):
           # if pair was found, remove both, add paired up network
           # to combinetons for next run and move along
           # otherwise this network can never be paired

--- a/tests/lib/summarizer_test.py
+++ b/tests/lib/summarizer_test.py
@@ -148,6 +148,22 @@ class SummarizerTest(unittest.TestCase):
         '00000000 00000000 00000000 00000000 00000000 00000000 00000000 '
         '00000000 00000001')
 
+  def testSummarizeDSMONetworks(self):
+    fourth_octet = [2,8,20,26,28,32,40,52,58,86,130,136,148,154,156,160,168,180,186,214]
+    nets = list()
+
+    for octet3 in range(56, 60):
+      for octet4 in fourth_octet:
+        nets.append(ipaddr.IPv4Network('192.168.' + str(octet3) + '.' + str(octet4) + '/31'))
+
+    result = summarizer.Summarize(nets)
+    self.assertEquals(result, [(3232249858, 4294966398),
+                               (3232249888, 4294966398),
+                               (3232249908, 4294966398),
+                               (3232249942, 4294966398),
+                               (3232249864, 4294966366),
+                               (3232249876, 4294966390),
+                               (3232249882, 4294966366)])
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
The module **summarizer.py** has a bug in the procedure **_SummarizeSameMask**. This procedure is used for the summarization of non contiguous subnet masks. During the summarization, the networks are sorted (after converting from "dot formatted" to integer) and then they are iterated several times to summarize them. But there is an issue when this summarization is done over a network already summarized in more than one octet. If two octets were already summarized the algorithm is failing because it's not taken into consideration the network mask after finding those networks are contiguous. This is the fix provided.

You can reproduce the issue if you create a simple policy file with only one term and only one object as source or destination and the following IPs inside NETWORK definition (I'm sorry I couldn't reduce the list more):

192.168.56.2/31
192.168.56.8/31
192.168.56.20/31
192.168.56.26/31
192.168.56.28/31
192.168.56.32/31
192.168.56.40/31
192.168.56.52/31
192.168.56.58/31
192.168.56.86/31
192.168.56.130/31
192.168.56.136/31
192.168.56.148/31
192.168.56.154/31
192.168.56.156/31
192.168.56.160/31
192.168.56.168/31
192.168.56.180/31
192.168.56.186/31
192.168.56.214/31
192.168.57.2/31
192.168.57.8/31
192.168.57.20/31
192.168.57.26/31
192.168.57.28/31
192.168.57.32/31
192.168.57.40/31
192.168.57.52/31
192.168.57.58/31
192.168.57.86/31
192.168.57.130/31
192.168.57.136/31
192.168.57.148/31
192.168.57.154/31
192.168.57.156/31
192.168.57.160/31
192.168.57.168/31
192.168.57.180/31
192.168.57.186/31
192.168.57.214/31
192.168.58.2/31
192.168.58.8/31
192.168.58.20/31
192.168.58.26/31
192.168.58.28/31
192.168.58.32/31
192.168.58.40/31
192.168.58.52/31
192.168.58.58/31
192.168.58.86/31
192.168.58.130/31
192.168.58.136/31
192.168.58.148/31
192.168.58.154/31
192.168.58.156/31
192.168.58.160/31
192.168.58.168/31
192.168.58.180/31
192.168.58.186/31
192.168.58.214/31
192.168.59.2/31
192.168.59.8/31
192.168.59.20/31
192.168.59.26/31
192.168.59.28/31
192.168.59.32/31
192.168.59.40/31
192.168.59.52/31
192.168.59.58/31
192.168.59.86/31
192.168.59.130/31
192.168.59.136/31
192.168.59.148/31
192.168.59.154/31
192.168.59.156/31
192.168.59.160/31
192.168.59.168/31
192.168.59.180/31
192.168.59.186/31
192.168.59.214/31