### PR TITLE
Fragments support in Cisco

### DIFF
--- a/capirca/lib/cisco.py
+++ b/capirca/lib/cisco.py
@@ -401,6 +401,9 @@ class Term(aclgenerator.Term):
         and ('tcp-established' in opts or 'established' in opts)):
       if 'established' not in self.options:
         self.options.append('established')
+    if ('ip' in protocol) and ('fragments' in opts):
+      if 'fragments' not in self.options:
+          self.options.append('fragments')
 
     # ports
     source_port = [()]
@@ -632,7 +635,9 @@ class Term(aclgenerator.Term):
   def _FixOptions(self, proto, option):
     """Returns a set of options suitable for the given protocol.
 
-    In practice this is only used to filter out 'established' for UDP.
+    Fix done:
+    - Filter out 'established' for UDP.
+    - Filter out 'fragments' for TCP/UDP
 
     Args:
       proto: str or int, protocol
@@ -645,6 +650,12 @@ class Term(aclgenerator.Term):
     if ((proto == self.PROTO_MAP['udp'] or proto == 'udp')
         and 'established' in sane_options):
       sane_options.remove('established')
+    if ((proto == self.PROTO_MAP['tcp'] or proto == 'tcp')
+        and 'fragments' in sane_options):
+      sane_options.remove('fragments')
+    if ((proto == self.PROTO_MAP['udp'] or proto == 'udp')
+        and 'fragments' in sane_options):
+      sane_options.remove('fragments')
     return sane_options
 
   def _TermletToStr(self, action, proto, saddr, sport, daddr, dport,
@@ -831,7 +842,8 @@ class Cisco(aclgenerator.ACLGenerator):
                          'owner'}
 
     supported_sub_tokens.update({'option': {'established',
-                                            'tcp-established'},
+                                            'tcp-established',
+                                            'fragments'},
                                  # Warning, some of these are mapped
                                  # differently. See _ACTION_TABLE
                                  'action': {'accept', 'deny', 'reject', 'next',

--- a/capirca/lib/cisco.py
+++ b/capirca/lib/cisco.py
@@ -650,12 +650,6 @@ class Term(aclgenerator.Term):
     if ((proto == self.PROTO_MAP['udp'] or proto == 'udp')
         and 'established' in sane_options):
       sane_options.remove('established')
-    if ((proto == self.PROTO_MAP['tcp'] or proto == 'tcp')
-        and 'fragments' in sane_options):
-      sane_options.remove('fragments')
-    if ((proto == self.PROTO_MAP['udp'] or proto == 'udp')
-        and 'fragments' in sane_options):
-      sane_options.remove('fragments')
     return sane_options
 
   def _TermletToStr(self, action, proto, saddr, sport, daddr, dport,

--- a/tests/lib/arista_test.py
+++ b/tests/lib/arista_test.py
@@ -171,7 +171,8 @@ SUPPORTED_SUB_TOKENS = {
         'version-2-multicast-listener-report',
     },
     'option': {'established',
-               'tcp-established'}
+               'tcp-established',
+               'fragments'}
 }
 
 # Print a info message when a term is set to expire in that many weeks.

--- a/tests/lib/brocade_test.py
+++ b/tests/lib/brocade_test.py
@@ -122,7 +122,8 @@ SUPPORTED_SUB_TOKENS = {
         'version-2-multicast-listener-report',
     },
     'option': {'established',
-               'tcp-established'}
+               'tcp-established',
+               'fragments'}
 }
 
 # Print a info message when a term is set to expire in that many weeks.

--- a/tests/lib/cisco_test.py
+++ b/tests/lib/cisco_test.py
@@ -284,6 +284,14 @@ term good_term_19 {
   action:: accept
 }
 """
+GOOD_TERM_20 = """
+term good_term_20 {
+  source-address:: SOME_HOST
+  destination-address:: SOME_HOST
+  option:: fragments
+  action:: accept
+}
+"""
 LONG_COMMENT_TERM = """
 term long-comment-term {
   comment:: "%s "
@@ -365,7 +373,8 @@ SUPPORTED_SUB_TOKENS = {
         'version-2-multicast-listener-report',
     },
     'option': {'established',
-               'tcp-established'}
+               'tcp-established',
+               'fragments'}
 }
 
 # Print a info message when a term is set to expire in that many weeks.
@@ -774,6 +783,16 @@ class CiscoTest(unittest.TestCase):
                     'established' in str(acl), str(acl))
     self.failUnless('permit udp any any range 1024 65535' in str(acl),
                     str(acl))
+
+  def testFragments(self):
+    self.naming.GetNetAddr.return_value = [nacaddr.IP('10.0.0.0/24')]
+    acl = cisco.Cisco(policy.ParsePolicy(GOOD_HEADER + GOOD_TERM_20,
+                                         self.naming), EXP_INFO)
+    first_string = 'permit ip 10.0.0.0 0.0.0.255 10.0.0.0 0.0.0.255 fragments'
+    self.failUnless(first_string in str(acl), str(acl))
+
+    self.naming.GetNetAddr.assert_has_calls([mock.call('SOME_HOST'),
+                                             mock.call('SOME_HOST')])
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/cisco_test.py
+++ b/tests/lib/cisco_test.py
@@ -788,8 +788,8 @@ class CiscoTest(unittest.TestCase):
     self.naming.GetNetAddr.return_value = [nacaddr.IP('10.0.0.0/24')]
     acl = cisco.Cisco(policy.ParsePolicy(GOOD_HEADER + GOOD_TERM_20,
                                          self.naming), EXP_INFO)
-    first_string = 'permit ip 10.0.0.0 0.0.0.255 10.0.0.0 0.0.0.255 fragments'
-    self.failUnless(first_string in str(acl), str(acl))
+    expected = 'permit ip 10.0.0.0 0.0.0.255 10.0.0.0 0.0.0.255 fragments'
+    self.failUnless(expected in str(acl), str(acl))
 
     self.naming.GetNetAddr.assert_has_calls([mock.call('SOME_HOST'),
                                              mock.call('SOME_HOST')])

--- a/tests/lib/ciscoxr_test.py
+++ b/tests/lib/ciscoxr_test.py
@@ -156,7 +156,8 @@ SUPPORTED_SUB_TOKENS = {
         'version-2-multicast-listener-report',
     },
     'option': {'established',
-               'tcp-established'}
+               'tcp-established',
+               'fragments'}
 }
 
 EXP_INFO = 2


### PR DESCRIPTION
Cisco ACL allows to handle specifically fragments adding the keyword "fragments" to the end of any L3 ACE. This PR will allow that through the use of "fragments" as an option in Capirca policy.