### PR TITLE
Improve flags message for base_directory

### DIFF
--- a/capirca/aclgen.py
+++ b/capirca/aclgen.py
@@ -58,7 +58,8 @@ flags.DEFINE_string(
     'base_directory',
     './policies',
     'The base directory to look for acls; '
-    'typically where you\'d find ./corp and ./prod')
+    'typically where you\'d find ./corp and ./prod.'
+    'Each one including a /pol folder where policies will be discovered')
 flags.DEFINE_string(
     'definitions_directory',
     './def',


### PR DESCRIPTION
Highlight that each directory under the base_directory should contain a "/pol" folder where the policies will be taken from.
It's just a  suggestion that I've come out after reviewing the code, and it will help others trying to customize capirca execution