### PR TITLE
Changed logging.basicConfig calls to logging.set_verbosity to work with absl logging

### DIFF
--- a/capirca/aclgen.py
+++ b/capirca/aclgen.py
@@ -449,9 +449,9 @@ def _WriteFile(output_file, file_string):
 
 def main(unused_argv):
   if FLAGS.verbose:
-    logging.basicConfig(level=logging.INFO)
+    logging.set_verbosity(logging.INFO)
   if FLAGS.debug:
-    logging.basicConfig(level=logging.DEBUG)
+    logging.set_verbosity(logging.DEBUG)
   logging.debug('binary: %s\noptimize: %d\nbase_directory: %s\n'
                 'policy_file: %s\nrendered_acl_directory: %s',
                 str(sys.argv[0]),


### PR DESCRIPTION
Trying to run aclgen with --debug or --verbose would fail with "AttributeError: 'module' object has no attribute 'basicConfig'"

Changing logging.basicConfig calls to use absl's logging.set_verbosity instead fixed the issue

(this is just a clean recreation of closed request #165 )