### PR TITLE
Fix Github Issue #187 with max backwards-compat (retaining support fo…

### DIFF
--- a/capirca/lib/cisco.py
+++ b/capirca/lib/cisco.py
@@ -735,7 +735,8 @@ class Term(aclgenerator.Term):
         and ('tcp-established' in opts or 'established' in opts)):
       if 'established' not in self.options:
         self.options.append('established')
-    if ('ip' in protocol) and ('fragments' in opts):
+    # Using both 'fragments' and 'is-fragment', ref Github Issue #187
+    if ('ip' in protocol) and (('fragments' in opts) or ('is-fragment' in opts)):
       if 'fragments' not in self.options:
         self.options.append('fragments')
 
@@ -1049,6 +1050,7 @@ class Cisco(aclgenerator.ACLGenerator):
 
     supported_sub_tokens.update({'option': {'established',
                                             'tcp-established',
+                                            'is-fragment',
                                             'fragments'},
                                  # Warning, some of these are mapped
                                  # differently. See _ACTION_TABLE

--- a/capirca/lib/cisco.py
+++ b/capirca/lib/cisco.py
@@ -736,7 +736,7 @@ class Term(aclgenerator.Term):
       if 'established' not in self.options:
         self.options.append('established')
     # Using both 'fragments' and 'is-fragment', ref Github Issue #187
-    if ('ip' in protocol) and (('fragments' in opts) or \
+    if ('ip' in protocol) and (('fragments' in opts) or 
       ('is-fragment' in opts)):
       if 'fragments' not in self.options:
         self.options.append('fragments')

--- a/capirca/lib/cisco.py
+++ b/capirca/lib/cisco.py
@@ -732,11 +732,12 @@ class Term(aclgenerator.Term):
     # options
     opts = [str(x) for x in self.term.option]
     if ((self.PROTO_MAP['tcp'] in protocol or 'tcp' in protocol)
-        and ('tcp-established' in opts or 'established' in opts)):
+      and ('tcp-established' in opts or 'established' in opts)):
       if 'established' not in self.options:
         self.options.append('established')
     # Using both 'fragments' and 'is-fragment', ref Github Issue #187
-    if ('ip' in protocol) and (('fragments' in opts) or ('is-fragment' in opts)):
+    if ('ip' in protocol) and (('fragments' in opts) or \
+      ('is-fragment' in opts)):
       if 'fragments' not in self.options:
         self.options.append('fragments')
 

--- a/capirca/lib/cisco.py
+++ b/capirca/lib/cisco.py
@@ -732,7 +732,7 @@ class Term(aclgenerator.Term):
     # options
     opts = [str(x) for x in self.term.option]
     if ((self.PROTO_MAP['tcp'] in protocol or 'tcp' in protocol)
-      and ('tcp-established' in opts or 'established' in opts)):
+       and ('tcp-established' in opts or 'established' in opts)):
       if 'established' not in self.options:
         self.options.append('established')
     # Using both 'fragments' and 'is-fragment', ref Github Issue #187

--- a/capirca/lib/cisco.py
+++ b/capirca/lib/cisco.py
@@ -736,7 +736,7 @@ class Term(aclgenerator.Term):
       if 'established' not in self.options:
         self.options.append('established')
     # Using both 'fragments' and 'is-fragment', ref Github Issue #187
-    if ('ip' in protocol) and (('fragments' in opts) or 
+    if ('ip' in protocol) and (('fragments' in opts) or
       ('is-fragment' in opts)):
       if 'fragments' not in self.options:
         self.options.append('fragments')

--- a/capirca/lib/cisco.py
+++ b/capirca/lib/cisco.py
@@ -732,7 +732,7 @@ class Term(aclgenerator.Term):
     # options
     opts = [str(x) for x in self.term.option]
     if ((self.PROTO_MAP['tcp'] in protocol or 'tcp' in protocol)
-       and ('tcp-established' in opts or 'established' in opts)):
+        and ('tcp-established' in opts or 'established' in opts)):
       if 'established' not in self.options:
         self.options.append('established')
     # Using both 'fragments' and 'is-fragment', ref Github Issue #187

--- a/tests/lib/arista_test.py
+++ b/tests/lib/arista_test.py
@@ -199,6 +199,7 @@ SUPPORTED_SUB_TOKENS = {
     },
     'option': {'established',
                'tcp-established',
+               'is-fragment',
                'fragments'}
 }
 

--- a/tests/lib/brocade_test.py
+++ b/tests/lib/brocade_test.py
@@ -123,6 +123,7 @@ SUPPORTED_SUB_TOKENS = {
     },
     'option': {'established',
                'tcp-established',
+               'is-fragment',
                'fragments'}
 }
 

--- a/tests/lib/ciscoxr_test.py
+++ b/tests/lib/ciscoxr_test.py
@@ -157,6 +157,7 @@ SUPPORTED_SUB_TOKENS = {
     },
     'option': {'established',
                'tcp-established',
+               'is-fragment',
                'fragments'}
 }
 


### PR DESCRIPTION
…r 'fragments')

I added a new `is-fragment` Cisco IOS ACL term option while retaining the old `fragments` option.  AFAICT, `is-fragment` is the preferred syntax (at least that's what the docs say). 