### PR TITLE
Fixed issue with WrapWords not breaking text with no spaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
   - "3.6"
   - "3.7"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install: "pip install -r requirements.txt -r test-requirements.txt"
 # command to run tests
-script: python -m unittest discover -s . -p '*_test.py'
+script: pytest tests/

--- a/capirca/lib/aclgenerator.py
+++ b/capirca/lib/aclgenerator.py
@@ -556,11 +556,12 @@ def WrapWords(textlist, size, joiner='\n'):
   Returns:
     list of strings
   """
-  # \S*? is a non greedy match to collect words of len > size
-  # .{1,%d} collects words and spaces up to size in length.
-  # (?:\s|\Z) ensures that we break on spaces or at end of string.
+  # \S{%d}(?!\s|\Z) collets the max size for words that are larger than the max
+  # (?<=\S{%d})\S+ collects the remaining text for overflow words in their own line
+  # \S.{1,%d}(?=\s|\Z)) collects all words and spaces up to max size, breaking at
+  #                     the last space
   rval = []
-  linelength_re = re.compile(r'(\S*?.{1,%d}(?:\s|\Z))' % size)
+  linelength_re = re.compile(r'(\S{%d}(?!\s|\Z)|(?<=\S{%d})\S+|\S.{1,%d}(?=\s|\Z))' % (size, size, size-1))
   for index in range(len(textlist)):
     if len(textlist[index]) > size:
       # insert joiner into the string at appropriate places.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@
 ipaddress>=1.0.22
 absl-py
 ply
-mock
 six>=1.12.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,11 @@
+attrs==19.3.0
+importlib-metadata==1.6.1
+mock==4.0.2
+more-itertools==8.3.0
+packaging==20.4
+pluggy==0.13.1
+py==1.8.1
+pyparsing==2.4.7
+pytest==5.4.3
+wcwidth==0.2.3
+zipp==3.1.0

--- a/tests/lib/aclgenerator_test.py
+++ b/tests/lib/aclgenerator_test.py
@@ -200,6 +200,5 @@ class ACLGeneratorTest(unittest.TestCase):
         ['%sId:%s' % ('$', '$')],
         aclgenerator.AddRepositoryTags(date=False, revision=False))
 
-
 if __name__ == '__main__':
   unittest.main()

--- a/tests/unit/wrapwords_test.py
+++ b/tests/unit/wrapwords_test.py
@@ -1,0 +1,64 @@
+import pytest
+from capirca.lib.aclgenerator import WrapWords
+
+SINGLE_LINE_OVERFLOW_TEXT_LONG = \
+    "http://github.com/google/capirca/commit/c5" + \
+    "6ddf19e2679892ff078cf27aeb18310c2697ed This " + \
+    "is a long header. It's long on purpose. It's " + \
+    "purpose is to test that the splitting works co" + \
+    "rrectly. It should be well over the line limit" + \
+    ". If it is shorter, it would not test the limit."
+
+SINGLE_LINE_OVERFLOW_TEXT_LONG_EXPECTED = [
+    'http://github.com/google/capirca/commit/c56ddf19e2679892ff078cf27aeb18', 
+    '310c2697ed', 
+    "This is a long header. It's long on purpose. It's purpose is to test", 
+    'that the splitting works correctly. It should be well over the line', 
+    'limit. If it is shorter, it would not test the limit.'
+]
+
+MULTI_LINE_OVERFLOW_TEXT_LONG = \
+    "this is a veryveryveryveryveryveryveryveryver" + \
+    "yveryveryveryveryveryveryveryveryveryveryvery" + \
+    "veryveryveryveryveryveryveryveryveryveryveryv" + \
+    "eryveryveryveryveryveryveryveryveryveryvery long word"
+
+MULTI_LINE_OVERFLOW_TEXT_LONG_EXPECTED = [
+    'this is a', 
+    'veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryve', 
+    'ryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryvery', 
+    'veryveryveryveryveryveryvery', 
+    'long word'
+]
+
+NO_OVERFLOW_LONG = \
+    "This " + \
+    "is a long header. It's long on purpose. It's " + \
+    "purpose is to test that the splitting works co" + \
+    "rrectly. It should be well over the line limit" + \
+    ". If it is shorter, it would not test the limit."
+
+NO_OVERFLOW_LONG_EXPECTED = [
+    "This is a long header. It's long on purpose. It's purpose is to test", 
+    'that the splitting works correctly. It should be well over the line', 
+    'limit. If it is shorter, it would not test the limit.'
+]
+
+NO_OVERFLOW_SHORT = \
+    "This is a short line of text"
+
+NO_OVERFLOW_SHORT_EXPECTED = [
+    "This is a short line of text"
+]
+
+@pytest.mark.parametrize("test_input,expected", [
+    (NO_OVERFLOW_SHORT, NO_OVERFLOW_SHORT_EXPECTED),
+    (NO_OVERFLOW_LONG, NO_OVERFLOW_LONG_EXPECTED),
+    (SINGLE_LINE_OVERFLOW_TEXT_LONG, SINGLE_LINE_OVERFLOW_TEXT_LONG_EXPECTED),
+    (MULTI_LINE_OVERFLOW_TEXT_LONG, MULTI_LINE_OVERFLOW_TEXT_LONG_EXPECTED)
+    ]
+)
+def testWrapWords(test_input, expected):
+    result = WrapWords([test_input], 70)
+
+    assert all((res == exp for res, exp in zip(result, expected)))


### PR DESCRIPTION
From @ankenyr :

"There is a hard line limit on certain platforms which is what the method WrapWord tries to fix. Currently the regular expression will break on whitespace. It however fails if a single "word" is over the limit. This ACL would be invalid and result in an error if you tried to apply it to a machine.

Instead I would expect it to try and break on whitespace but if it cannot and a single "word" exceeds the max character, force the break at the max"

