### PR TITLE
Fixed deprecation warnings

### DIFF
--- a/capirca/aclgen.py
+++ b/capirca/aclgen.py
@@ -184,7 +184,7 @@ def RenderFile(base_directory, input_file, output_directory, definitions,
       conf = f.read()
       logging.debug('opened and read %s', input_file)
   except IOError as e:
-    logging.warn('bad file: \n%s', e)
+    logging.warning('bad file: \n%s', e)
     raise
 
   try:
@@ -192,7 +192,7 @@ def RenderFile(base_directory, input_file, output_directory, definitions,
         conf, definitions, optimize=FLAGS.optimize,
         base_dir=base_directory, shade_check=FLAGS.shade_check)
   except policy.ShadingError as e:
-    logging.warn('shading errors for %s:\n%s', input_file, e)
+    logging.warning('shading errors for %s:\n%s', input_file, e)
     return
   except (policy.Error, naming.Error):
     raise ACLParserError('Error parsing policy file %s:\n%s%s' % (
@@ -427,12 +427,12 @@ def DescendRecursively(input_dirname, output_dirname, definitions, depth=1):
       # directory has a policy directory
       if curdir in FLAGS.ignore_directories:
         continue
-      logging.warn('-' * (2 * depth) + '> %s' % (
+      logging.warning('-' * (2 * depth) + '> %s' % (
           input_dirname + '/' + curdir))
       files_found = DescendRecursively(input_dirname + '/' + curdir,
                                        output_dirname + '/' + curdir,
                                        definitions, depth + 1)
-      logging.warn('-' * (2 * depth) + '> %s (%d pol files found)' % (
+      logging.warning('-' * (2 * depth) + '> %s (%d pol files found)' % (
           input_dirname + '/' + curdir, len(files_found)))
       files.extend(files_found)
 
@@ -459,7 +459,7 @@ def _WriteFile(output_file, file_string):
       logging.info('writing file: %s', output_file)
       output.write(file_string)
   except IOError:
-    logging.warn('error while writing file: %s', output_file)
+    logging.warning('error while writing file: %s', output_file)
     raise
 
 
@@ -507,13 +507,13 @@ def Run(base_directory, definitions_directory, policy_file, output_directory,
         result.get()
       except (ACLParserError, ACLGeneratorError) as e:
         with_errors = True
-        logging.warn('\n\nerror encountered in rendering process:\n%s\n\n', e)
+        logging.warning('\n\nerror encountered in rendering process:\n%s\n\n', e)
 
   # actually write files to disk
   WriteFiles(write_files)
 
   if with_errors:
-    logging.warn('done, with errors.')
+    logging.warning('done, with errors.')
     sys.exit(1)
   else:
     logging.info('done.')

--- a/capirca/lib/aruba.py
+++ b/capirca/lib/aruba.py
@@ -308,7 +308,7 @@ class Aruba(aclgenerator.ACLGenerator):
                          'in less than two weeks.', term.name, filter_name)
 
           if term.expiration <= current_date:
-            logging.warn('WARNING: Term %s in policy %s is expired and '
+            logging.warning('WARNING: Term %s in policy %s is expired and '
                          'will not be rendered.', term.name, filter_name)
             continue
 

--- a/capirca/lib/cisco.py
+++ b/capirca/lib/cisco.py
@@ -97,13 +97,13 @@ class TermStandard(object):
       raise StandardAclTermError(
           'Standard ACLs prohibit use of port numbers')
     if self.term.logging:
-      logging.warn(
+      logging.warning(
           'WARNING: Standard ACL logging is set in filter %s, term %s and '
           'may not implemented on all IOS versions', self.filter_name,
           self.term.name)
       self.logstring = ' log'
     if self.term.dscp_match:
-      logging.warn(
+      logging.warning(
           'WARNING: dscp-match is set in filter %s, term %s and may not be '
           'implemented on all IOS version', self.filter_name, self.term.name)
       self.dscpstring = ' dscp' + self.term.dscp_match
@@ -1159,7 +1159,7 @@ class Cisco(aclgenerator.ACLGenerator):
               logging.info('INFO: Term %s in policy %s expires '
                            'in less than two weeks.', term.name, filter_name)
             if term.expiration <= current_date:
-              logging.warn('WARNING: Term %s in policy %s is expired and '
+              logging.warning('WARNING: Term %s in policy %s is expired and '
                            'will not be rendered.', term.name, filter_name)
               continue
 

--- a/capirca/lib/ciscoasa.py
+++ b/capirca/lib/ciscoasa.py
@@ -335,7 +335,7 @@ class CiscoASA(aclgenerator.ACLGenerator):
             logging.info('INFO: Term %s in policy %s expires '
                          'in less than two weeks.', term.name, filter_name)
           if term.expiration <= current_date:
-            logging.warn('WARNING: Term %s in policy %s is expired and '
+            logging.warning('WARNING: Term %s in policy %s is expired and '
                          'will not be rendered.', term.name, filter_name)
             continue
 

--- a/capirca/lib/cloudarmor.py
+++ b/capirca/lib/cloudarmor.py
@@ -80,7 +80,7 @@ class Term(aclgenerator.Term):
       raw_comment = ' '.join(self.term.comment)
       if len(raw_comment) > self._MAX_TERM_COMMENT_LENGTH:
         term_dict['description'] = raw_comment[:self._MAX_TERM_COMMENT_LENGTH]
-        logging.warn('Term comment exceeds maximum length = %d; Truncating '
+        logging.warning('Term comment exceeds maximum length = %d; Truncating '
                      'comment..', self._MAX_TERM_COMMENT_LENGTH)
       else:
         term_dict['description'] = raw_comment
@@ -246,7 +246,7 @@ class CloudArmor(aclgenerator.ACLGenerator):
                                         ' a single policy | MAX = %d'
                                         % self._MAX_RULES_PER_POLICY)
           else:
-            logging.warn('Current rule count (%d) is almost at maximum limit '
+            logging.warning('Current rule count (%d) is almost at maximum limit '
                          ' of %d', total_rule_count, self._MAX_RULES_PER_POLICY)
 
   def __str__(self):

--- a/capirca/lib/demo.py
+++ b/capirca/lib/demo.py
@@ -209,7 +209,7 @@ class Demo(aclgenerator.ACLGenerator):
             logging.info('INFO: Term %s in policy %s expires '
                          'in less than two weeks.', term.name, filter_name)
           if term.expiration <= current_date:
-            logging.warn('WARNING: Term %s in policy %s is expired and '
+            logging.warning('WARNING: Term %s in policy %s is expired and '
                          'will not be rendered.', term.name, filter_name)
             continue
         new_terms.append(Term(term, filter_type))

--- a/capirca/lib/gce.py
+++ b/capirca/lib/gce.py
@@ -325,7 +325,7 @@ class GCE(aclgenerator.ACLGenerator):
       if filter_options:
         network = filter_options[0]
       else:
-        logging.warn('GCE filter does not specify a network.')
+        logging.warning('GCE filter does not specify a network.')
 
       term_names = set()
       if IsDefaultDeny(terms[-1]):
@@ -342,7 +342,7 @@ class GCE(aclgenerator.ACLGenerator):
 
       for term in terms:
         if term.stateless_reply:
-          logging.warn('WARNING: Term %s in policy %s is a stateless reply '
+          logging.warning('WARNING: Term %s in policy %s is a stateless reply '
                        'term and will not be rendered.',
                        term.name, filter_name)
           continue
@@ -362,7 +362,7 @@ class GCE(aclgenerator.ACLGenerator):
             logging.info('INFO: Term %s in policy %s expires '
                          'in less than two weeks.', term.name, filter_name)
           if term.expiration <= current_date:
-            logging.warn('WARNING: Term %s in policy %s is expired and '
+            logging.warning('WARNING: Term %s in policy %s is expired and '
                          'will not be rendered.', term.name, filter_name)
             continue
         if term.option:

--- a/capirca/lib/iptables.py
+++ b/capirca/lib/iptables.py
@@ -191,7 +191,7 @@ class Term(aclgenerator.Term):
     else:
       protocol = ['all']
     if 'hopopt' in protocol and self.af == 'inet':
-      logging.warn('Term %s is using hopopt in IPv4 context.', self.term_name)
+      logging.warning('Term %s is using hopopt in IPv4 context.', self.term_name)
       return ''
 
     (term_saddr, exclude_saddr,
@@ -690,7 +690,7 @@ class Iptables(aclgenerator.ACLGenerator):
   def _WarnIfCustomTarget(self, target):
     """Emit a warning if a policy's default target is not a built-in chain."""
     if target not in self._GOOD_FILTERS:
-      logging.warn('Filter is generating a non-standard chain that will not '
+      logging.warning('Filter is generating a non-standard chain that will not '
                    'apply to traffic unless linked from INPUT, OUTPUT or '
                    'FORWARD filters. New chain name is: %s', target)
 
@@ -780,7 +780,7 @@ class Iptables(aclgenerator.ACLGenerator):
             logging.info('INFO: Term %s in policy %s expires '
                          'in less than two weeks.', term.name, filter_name)
           if term.expiration <= current_date:
-            logging.warn('WARNING: Term %s in policy %s is expired and '
+            logging.warning('WARNING: Term %s in policy %s is expired and '
                          'will not be rendered.', term.name, filter_name)
             continue
 

--- a/capirca/lib/juniper.py
+++ b/capirca/lib/juniper.py
@@ -604,7 +604,7 @@ class Term(aclgenerator.Term):
       if self.term.policer:
         config.Append('policer %s;' % self.term.policer)
         if len(self.term.policer) > oid_length:
-          logging.warn('WARNING: %s is longer than %d bytes. Due to limitation'
+          logging.warning('WARNING: %s is longer than %d bytes. Due to limitation'
                        ' in JUNOS, OIDs longer than %dB can cause SNMP '
                        'timeout issues.',
                        self.term.policer, oid_length, oid_length)
@@ -942,7 +942,7 @@ class Juniper(aclgenerator.ACLGenerator):
             logging.info('INFO: Term %s in policy %s expires '
                          'in less than two weeks.', term.name, filter_name)
           if term.expiration <= current_date:
-            logging.warn('WARNING: Term %s in policy %s is expired and '
+            logging.warning('WARNING: Term %s in policy %s is expired and '
                          'will not be rendered.', term.name, filter_name)
             continue
         if 'is-fragment' in term.option and filter_type == 'inet6':

--- a/capirca/lib/junipersrx.py
+++ b/capirca/lib/junipersrx.py
@@ -463,7 +463,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                          'in less than two weeks.', term.name, self.from_zone,
                          self.to_zone)
           if term.expiration <= current_date:
-            logging.warn('WARNING: Term %s in policy %s>%s is expired.',
+            logging.warning('WARNING: Term %s in policy %s>%s is expired.',
                          term.name, self.from_zone, self.to_zone)
             continue
 
@@ -598,7 +598,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
     for term in terms:
       if (term.AddressesByteLength(
           self._AF_MAP[address_family]) > self._ADDRESS_LENGTH_LIMIT):
-        logging.warn('LARGE TERM ENCOUNTERED')
+        logging.warning('LARGE TERM ENCOUNTERED')
         src_chunks = Chunks(term.source_address)
         counter = 0
         for chunk in src_chunks:

--- a/capirca/lib/nftables.py
+++ b/capirca/lib/nftables.py
@@ -125,7 +125,7 @@ class Term(aclgenerator.Term):
       src_addrs = self._CalculateAddrs(self.term.source_address,
                                        self.term.source_address_exclude)
       if not src_addrs:
-        logging.warn(self.NO_AF_LOG_ADDR.substitute(term=self.term.name,
+        logging.warning(self.NO_AF_LOG_ADDR.substitute(term=self.term.name,
                                                     direction='source',
                                                     af=self.af))
         return ''
@@ -137,7 +137,7 @@ class Term(aclgenerator.Term):
       dst_addrs = self._CalculateAddrs(self.term.destination_address,
                                        self.term.destination_address_exclude)
       if not dst_addrs:
-        logging.warn(self.NO_AF_LOG_ADDR.substitute(term=self.term.name,
+        logging.warning(self.NO_AF_LOG_ADDR.substitute(term=self.term.name,
                                                     direction='destination',
                                                     af=self.af))
         return ''
@@ -208,7 +208,7 @@ class Term(aclgenerator.Term):
       if len(comment_data) > self.MAX_CHARACTERS:
         # Have to use the first MAX_CHARACTERS characters
         comment_data = comment_data[:self.MAX_CHARACTERS]
-        logging.warn(
+        logging.warning(
             'Term %s in policy is too long (>%d characters) '
             'and will be truncated', self.term.name, self.MAX_CHARACTERS)
 
@@ -350,7 +350,7 @@ class Nftables(aclgenerator.ACLGenerator):
 
         if term.expiration:
           if term.expiration < current_date:
-            logging.warn(
+            logging.warning(
                 'Term %s in policy %s is expired and will not be rendered.',
                 term.name, chain_name)
             continue

--- a/capirca/lib/nsxv.py
+++ b/capirca/lib/nsxv.py
@@ -175,7 +175,7 @@ class Term(aclgenerator.Term):
         if ('translated' not in key) and (key not in _NSXV_SUPPORTED_KEYWORDS):
           unsupported_keywords.append(key)
     if unsupported_keywords:
-      logging.warn('WARNING: The keywords %s in Term %s are not supported in '
+      logging.warning('WARNING: The keywords %s in Term %s are not supported in '
                    'Nsxv ', unsupported_keywords, self.term.name)
 
     name = '%s%s%s' % (_XML_TABLE.get('nameStart'), self.term.name,
@@ -268,7 +268,7 @@ class Term(aclgenerator.Term):
           destination_addr = dest_v4_addr
 
         if not source_addr or not destination_addr:
-          logging.warn('Term %s will not be rendered as it has IPv4/IPv6 '
+          logging.warning('Term %s will not be rendered as it has IPv4/IPv6 '
                        'mismatch for source/destination for mixed address '
                        'family.', self.term.name)
           return ''
@@ -517,14 +517,14 @@ class Nsxv(aclgenerator.ACLGenerator):
             logging.info('INFO: Term %s in policy %s expires '
                          'in less than two weeks.', term.name, filter_name)
           if term.expiration <= current_date:
-            logging.warn('WARNING: Term %s in policy %s is expired and '
+            logging.warning('WARNING: Term %s in policy %s is expired and '
                          'will not be rendered.', term.name, filter_name)
             continue
         # Get the mapped action value
         # If there is no mapped action value term is not rendered
         mapped_action = _ACTION_TABLE.get(str(term.action[0]))
         if not mapped_action:
-          logging.warn('WARNING: Action %s in Term %s is not valid and '
+          logging.warning('WARNING: Action %s in Term %s is not valid and '
                        'will not be rendered.', term.action, term.name)
           continue
 
@@ -632,7 +632,7 @@ class Nsxv(aclgenerator.ACLGenerator):
       # check section id value
       section_id = self._FILTER_OPTIONS_DICT['section_id']
       if not section_id or section_id == 0:
-        logging.warn('WARNING: Section-id is 0. A new Section is created for%s.'
+        logging.warning('WARNING: Section-id is 0. A new Section is created for%s.'
                      ' If there is any existing section, it will remain '
                      'unreferenced and should be removed manually.',
                      section_name)

--- a/capirca/lib/packetfilter.py
+++ b/capirca/lib/packetfilter.py
@@ -520,7 +520,7 @@ class PacketFilter(aclgenerator.ACLGenerator):
             logging.info('INFO: Term %s in policy %s expires '
                          'in less than two weeks.', term.name, filter_name)
           if term.expiration <= current_date:
-            logging.warn('WARNING: Term %s in policy %s is expired and '
+            logging.warning('WARNING: Term %s in policy %s is expired and '
                          'will not be rendered.', term.name, filter_name)
             continue
 

--- a/capirca/lib/paloaltofw.py
+++ b/capirca/lib/paloaltofw.py
@@ -349,7 +349,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
                          "in less than two weeks.", term.name, self.from_zone,
                          self.to_zone)
           if term.expiration <= current_date:
-            logging.warn("WARNING: Term %s in policy %s>%s is expired and "
+            logging.warning("WARNING: Term %s in policy %s>%s is expired and "
                          "will not be rendered.",
                          term.name, self.from_zone, self.to_zone)
             continue

--- a/capirca/lib/pcap.py
+++ b/capirca/lib/pcap.py
@@ -424,7 +424,7 @@ class PcapFilter(aclgenerator.ACLGenerator):
             logging.info('INFO: Term %s in policy %s expires '
                          'in less than two weeks.', term.name, filter_name)
           if term.expiration <= current_date:
-            logging.warn('WARNING: Term %s in policy %s is expired and '
+            logging.warning('WARNING: Term %s in policy %s is expired and '
                          'will not be rendered.', term.name, filter_name)
             continue
 

--- a/capirca/lib/policy.py
+++ b/capirca/lib/policy.py
@@ -153,7 +153,7 @@ def TranslatePorts(ports, protocols, term_name):
     for port in ports:
       service_by_proto = DEFINITIONS.GetServiceByProto(port, proto)
       if not service_by_proto:
-        logging.warn('%s %s %s %s %s %s%s %s', 'Term', term_name,
+        logging.warning('%s %s %s %s %s %s%s %s', 'Term', term_name,
                      'has service', port, 'which is not defined with protocol',
                      proto,
                      ', but will be permitted. Unless intended, you should',

--- a/capirca/lib/windows.py
+++ b/capirca/lib/windows.py
@@ -309,7 +309,7 @@ class WindowsGenerator(aclgenerator.ACLGenerator):
             logging.info('INFO: Term %s in policy %s expires '
                          'in less than two weeks.', term.name, filter_name)
           if term.expiration <= current_date:
-            logging.warn('WARNING: Term %s in policy %s is expired and '
+            logging.warning('WARNING: Term %s in policy %s is expired and '
                          'will not be rendered.', term.name, filter_name)
             continue
         if 'established' in term.option or 'tcp-established' in term.option:

--- a/capirca/lib/windows_ipsec.py
+++ b/capirca/lib/windows_ipsec.py
@@ -102,13 +102,13 @@ class Term(windows.Term):
     # yup, the full cartesian product... this makes me cry on the inside.
     for saddr in src_addr:
       if saddr.version != 4:
-        logging.warn('WARNING: term contains a non IPv4 address %s, '
+        logging.warning('WARNING: term contains a non IPv4 address %s, '
                      'ignoring element of term %s.', saddr, self.term_name)
         continue
 
       for daddr in dst_addr:
         if daddr.version != 4:
-          logging.warn('WARNING: term contains a non IPv4 address %s, '
+          logging.warning('WARNING: term contains a non IPv4 address %s, '
                        'ignoring element of term %s.', daddr, self.term_name)
           continue
 

--- a/tests/lib/aruba_test.py
+++ b/tests/lib/aruba_test.py
@@ -255,7 +255,7 @@ class ArubaTest(unittest.TestCase):
     self.assertEqual(SUPPORTED_TOKENS, st)
     self.assertEqual(SUPPORTED_SUB_TOKENS, sst)
 
-  @mock.patch.object(logging, 'warn')
+  @mock.patch.object(logging, 'warning')
   def testExpiredTerm(self, mock_warn):
     aruba.Aruba(policy.ParsePolicy(GOOD_HEADER_V4 + EXPIRED_TERM,
                                    self.naming), EXP_INFO)

--- a/tests/lib/cisco_test.py
+++ b/tests/lib/cisco_test.py
@@ -764,7 +764,7 @@ class CiscoTest(unittest.TestCase):
                                          self.naming), EXP_INFO)
     self.assertTrue(re.search('permit ipv6 any any', str(acl)), str(acl))
 
-  @mock.patch.object(cisco.logging, 'warn')
+  @mock.patch.object(cisco.logging, 'warning')
   def testExpiredTerm(self, mock_warn):
     _ = cisco.Cisco(policy.ParsePolicy(GOOD_HEADER + EXPIRED_TERM,
                                        self.naming), EXP_INFO)
@@ -835,7 +835,7 @@ class CiscoTest(unittest.TestCase):
     acl = cisco.Cisco(policy.ParsePolicy(GOOD_HEADER + GOOD_TERM_21,
                                          self.naming), EXP_INFO)
     expected = 'permit ip 10.0.0.0 0.0.0.255 10.0.0.0 0.0.0.255'
-    self.failUnless(expected in str(acl), str(acl))
+    self.assertTrue(expected in str(acl), str(acl))
 
     self.naming.GetNetAddr.assert_has_calls([mock.call('cs4-valid_network_name'),
                                              mock.call('cs4-valid_network_name')])

--- a/tests/lib/cloudarmor_test.py
+++ b/tests/lib/cloudarmor_test.py
@@ -676,7 +676,7 @@ class CloudArmorTest(unittest.TestCase):
 
     self.naming.GetNetAddr.return_value = TEST_IPS_NOSPLIT
 
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         cloudarmor.UnsupportedFilterTypeError,
         "'inet8' is not a valid filter type",
         cloudarmor.CloudArmor,
@@ -696,7 +696,7 @@ class CloudArmorTest(unittest.TestCase):
 
     self.naming.GetNetAddr.return_value = test_1001_ips_list
 
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         cloudarmor.ExceededMaxTermsError,
         'Exceeded maximum number of rules in a single policy | MAX = 200',
         cloudarmor.CloudArmor,

--- a/tests/lib/gce_test.py
+++ b/tests/lib/gce_test.py
@@ -621,7 +621,7 @@ class GCETest(unittest.TestCase):
   def testRaisesWithoutSource(self):
     self.naming.GetServiceByProto.return_value = ['22']
 
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         gce.GceFirewallError,
         'Ingress rule missing required field oneof "sourceRanges" or "sourceTags.',
         gce.GCE,
@@ -635,7 +635,7 @@ class GCETest(unittest.TestCase):
     self.naming.GetNetAddr.return_value = TEST_EXCLUDE_IPS
     self.naming.GetServiceByProto.return_value = ['22']
 
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         gce.GceFirewallError,
         ('GCE firewall does not support address exclusions without a source '
          'address list.'),
@@ -651,7 +651,7 @@ class GCETest(unittest.TestCase):
     self.naming.GetNetAddr.side_effect = [TEST_INCLUDE_IPS, TEST_INCLUDE_IPS]
     self.naming.GetServiceByProto.side_effect = [['53'], ['53']]
 
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         gce.GceFirewallError,
         ('GCE firewall rule no longer contains any source addresses after '
          'the prefixes in source_address_exclude were removed.'),
@@ -671,7 +671,7 @@ class GCETest(unittest.TestCase):
     self.naming.GetNetAddr.return_value = TEST_IPS
     self.naming.GetServiceByProto.return_value = ['22']
 
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         gce.GceFirewallError,
         'GCE firewall does not support source port restrictions.',
         gce.GCE,
@@ -700,7 +700,7 @@ class GCETest(unittest.TestCase):
     self.naming.GetNetAddr.return_value = TEST_IPS
     self.naming.GetServiceByProto.return_value = ['22']
 
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         gce.GceFirewallError,
         'GCE firewall does not support term options.',
         gce.GCE,
@@ -758,7 +758,7 @@ class GCETest(unittest.TestCase):
   def testRaisesWithEgressDestinationTag(self):
     self.naming.GetNetAddr.return_value = TEST_IPS
     self.naming.GetServiceByProto.side_effect = [['53'], ['53']]
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         gce.GceFirewallError,
         'GCE Egress rule cannot have destination tag.',
         gce.GCE,
@@ -774,7 +774,7 @@ class GCETest(unittest.TestCase):
   def testRaisesWithEgressSourceAddress(self):
     self.naming.GetNetAddr.return_value = TEST_IPS
     self.naming.GetServiceByProto.side_effect = [['53'], ['53']]
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         gce.GceFirewallError,
         'Egress rules cannot include "sourceRanges".',
         gce.GCE,
@@ -789,7 +789,7 @@ class GCETest(unittest.TestCase):
   def testRaisesWithEgressSourceAndDestTag(self):
     self.naming.GetNetAddr.return_value = TEST_IPS
     self.naming.GetServiceByProto.side_effect = [['53'], ['53']]
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         gce.GceFirewallError,
         'GCE Egress rule cannot have destination tag.',
         gce.GCE,
@@ -842,14 +842,14 @@ class GCETest(unittest.TestCase):
     self.naming.GetNetAddr.return_value = TEST_IPS
     self.naming.GetServiceByProto.return_value = ['22']
 
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         gce.GceFirewallError,
         'Ingress rule missing required field oneof "sourceRanges" or "sourceTags"',
         gce.GCE,
         policy.ParsePolicy(
             GOOD_HEADER_INGRESS + GOOD_TERM_4, self.naming),
         EXP_INFO)
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         gce.GceFirewallError,
         'Egress rules cannot include "sourceRanges".',
         gce.GCE,

--- a/tests/lib/iptables_test.py
+++ b/tests/lib/iptables_test.py
@@ -579,7 +579,7 @@ class AclCheckTest(unittest.TestCase):
     super(AclCheckTest, self).setUp()
     self.naming = mock.create_autospec(naming.Naming)
 
-  @mock.patch.object(iptables.logging, 'warn')
+  @mock.patch.object(iptables.logging, 'warning')
   def testChainFilter(self, mock_warn):
     filter_name = 'foobar_chain'
     pol = policy.ParsePolicy(CHAIN_HEADER_1 + GOOD_TERM_1, self.naming)
@@ -1115,7 +1115,7 @@ class AclCheckTest(unittest.TestCase):
     self.assertIn('-o eth0', result,
                   'destination interface specification not in output.')
 
-  @mock.patch.object(iptables.logging, 'warn')
+  @mock.patch.object(iptables.logging, 'warning')
   def testExpired(self, mock_warn):
     _ = iptables.Iptables(policy.ParsePolicy(GOOD_HEADER_1 + EXPIRED_TERM,
                                              self.naming), EXP_INFO)

--- a/tests/lib/juniper_test.py
+++ b/tests/lib/juniper_test.py
@@ -735,7 +735,7 @@ class JuniperTest(unittest.TestCase):
     jcl = juniper.Juniper(policy.ParsePolicy(GOOD_HEADER + GOOD_TERM_36,
                                              self.naming), EXP_INFO)
     output = str(jcl)
-    self.failUnless('inactive: term good-term-36 {' in output, output)
+    self.assertTrue('inactive: term good-term-36 {' in output, output)
 
 
   def testInet6(self):
@@ -1134,7 +1134,7 @@ class JuniperTest(unittest.TestCase):
         ' as it has icmp match specified but '
         'the ACL is of inet6 address family.')
 
-  @mock.patch.object(juniper.logging, 'warn')
+  @mock.patch.object(juniper.logging, 'warning')
   def testExpiredTerm(self, mock_warn):
     _ = juniper.Juniper(policy.ParsePolicy(GOOD_HEADER + EXPIRED_TERM,
                                            self.naming), EXP_INFO)
@@ -1302,7 +1302,7 @@ class JuniperTest(unittest.TestCase):
                   output)
 
   def testLongPolicer(self):
-    with mock.patch.object(juniper.logging, 'warn', spec=logging.warn) as warn:
+    with mock.patch.object(juniper.logging, 'warning', spec=logging.warn) as warn:
       policy_text = GOOD_HEADER + LONG_POLICER_TERM_1
       jcl = juniper.Juniper(policy.ParsePolicy(policy_text, self.naming),
                             EXP_INFO)

--- a/tests/lib/junipersrx_test.py
+++ b/tests/lib/junipersrx_test.py
@@ -845,7 +845,7 @@ class JuniperSRXTest(unittest.TestCase):
     self.naming.GetNetAddr.assert_called_once_with('SOME_HOST')
     self.naming.GetServiceByProto.assert_called_once_with('SMTP', 'tcp')
 
-  @mock.patch.object(junipersrx.logging, 'warn')
+  @mock.patch.object(junipersrx.logging, 'warning')
   def testExpiredTerm(self, mock_warn):
     _ = junipersrx.JuniperSRX(policy.ParsePolicy(GOOD_HEADER + EXPIRED_TERM_1,
                                                  self.naming), EXP_INFO)

--- a/tests/lib/nftables_test.py
+++ b/tests/lib/nftables_test.py
@@ -350,7 +350,7 @@ class NftablesTest(unittest.TestCase):
         'table ip6 table_filter {\n\tchain chain_name {\n\t\ttype filter '
         'hook input priority 0;\n\t\tdrop\n\t}\n}', nft)
 
-  @mock.patch.object(logging, 'warn')
+  @mock.patch.object(logging, 'warning')
   def testExpired(self, mock_logging_warn):
     nftables.Nftables(policy.ParsePolicy(GOOD_HEADER_1 + EXPIRED_TERM,
                                          self.mock_naming), EXP_INFO)
@@ -463,7 +463,7 @@ class NftablesTest(unittest.TestCase):
     self.assertIn('comment "comment first line comment second line '
                   'Owner: owner@enterprise.com"', nft)
 
-  @mock.patch.object(logging, 'warn')
+  @mock.patch.object(logging, 'warning')
   def testCommentTruncate(self, mock_logging_warn):
     nft = str(nftables.Nftables(policy.ParsePolicy(GOOD_HEADER_1 + GOOD_TERM_17,
                                                    self.mock_naming), EXP_INFO))

--- a/tests/lib/packetfilter_test.py
+++ b/tests/lib/packetfilter_test.py
@@ -460,7 +460,7 @@ class PacketFilterTest(unittest.TestCase):
         GOOD_HEADER + BAD_TERM_ICMP, self.naming), EXP_INFO)
     self.assertRaises(aclgenerator.UnsupportedFilterError, str, acl)
 
-  @mock.patch.object(packetfilter.logging, 'warn')
+  @mock.patch.object(packetfilter.logging, 'warning')
   def testExpiredTerm(self, mock_warn):
     packetfilter.PacketFilter(policy.ParsePolicy(
         GOOD_HEADER + EXPIRED_TERM, self.naming), EXP_INFO)
@@ -470,7 +470,7 @@ class PacketFilterTest(unittest.TestCase):
         'will not be rendered.', 'expired_test',
         'test-filter')
 
-  @mock.patch.object(packetfilter.logging, 'warn')
+  @mock.patch.object(packetfilter.logging, 'warning')
   def testExpiredTerm2(self, mock_warn):
     packetfilter.PacketFilter(policy.ParsePolicy(
         GOOD_HEADER + EXPIRED_TERM2, self.naming), EXP_INFO)

--- a/tests/lib/pcap_test.py
+++ b/tests/lib/pcap_test.py
@@ -337,7 +337,7 @@ class PcapFilter(unittest.TestCase):
     self.assertRaises(aclgenerator.UnsupportedFilterError,
                       str, acl)
 
-  @mock.patch.object(pcap.logging, 'warn')
+  @mock.patch.object(pcap.logging, 'warning')
   def testExpiredTerm(self, mock_warn):
     pcap.PcapFilter(policy.ParsePolicy(
         GOOD_HEADER + EXPIRED_TERM, self.naming), EXP_INFO)

--- a/tests/lib/policy_test.py
+++ b/tests/lib/policy_test.py
@@ -954,7 +954,7 @@ class PolicyTest(unittest.TestCase):
 
   def testErrorLineNumber(self):
     pol = HEADER + GOOD_TERM_13 + BAD_TERM_8
-    self.assertRaisesRegexp(policy.ParseError,
+    self.assertRaisesRegex(policy.ParseError,
                             r'ERROR on "akshun" \(type STRING, line 1',
                             policy.ParsePolicy, pol, self.naming)
 

--- a/tests/lib/srxlo_test.py
+++ b/tests/lib/srxlo_test.py
@@ -204,7 +204,7 @@ class SRXloTest(unittest.TestCase):
   def testInactiveTerm(self):
       output = str(srxlo.SRXlo(policy.ParsePolicy(GOOD_HEADER_1 + GOOD_TERM_3,
                                                   self.naming), EXP_INFO))
-      self.failUnless('inactive: term good-term-3 {' in output, output)
+      self.assertTrue('inactive: term good-term-3 {' in output, output)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/windows_advfirewall_test.py
+++ b/tests/lib/windows_advfirewall_test.py
@@ -268,7 +268,7 @@ class WindowsAdvFirewallTest(unittest.TestCase):
     super(WindowsAdvFirewallTest, self).setUp()
     self.naming = mock.create_autospec(naming.Naming)
 
-  def FailUnless(self, strings, result, term):
+  def assertTrue(self, strings, result, term):
     for string in strings:
       fullstring = 'netsh advfirewall firewall add rule %s' % (string)
       super(WindowsAdvFirewallTest, self).assertIn(
@@ -282,7 +282,7 @@ class WindowsAdvFirewallTest(unittest.TestCase):
     acl = windows_advfirewall.WindowsAdvFirewall(policy.ParsePolicy(
         GOOD_HEADER_OUT + GOOD_TERM_TCP, self.naming), EXP_INFO)
     result = str(acl)
-    self.FailUnless(
+    self.assertTrue(
         ['name=o_good-term-tcp enable=yes interfacetype=any dir=out localip=any'
          ' remoteip=10.0.0.0/8 remoteport=25 protocol=tcp action=allow'],
         result,
@@ -295,7 +295,7 @@ class WindowsAdvFirewallTest(unittest.TestCase):
     acl = windows_advfirewall.WindowsAdvFirewall(policy.ParsePolicy(
         GOOD_HEADER_OUT + GOOD_TERM_ICMP, self.naming), EXP_INFO)
     result = str(acl)
-    self.FailUnless(
+    self.assertTrue(
         ['name=o_good-term-icmp enable=yes interfacetype=any dir=out'
          ' localip=any remoteip=any protocol=icmpv4 action=allow'],
         result,
@@ -305,7 +305,7 @@ class WindowsAdvFirewallTest(unittest.TestCase):
     acl = windows_advfirewall.WindowsAdvFirewall(policy.ParsePolicy(
         GOOD_HEADER_OUT + GOOD_TERM_ICMP_TYPES, self.naming), EXP_INFO)
     result = str(acl)
-    self.FailUnless(
+    self.assertTrue(
         ['name=o_good-term-icmp-types enable=yes interfacetype=any dir=out'
          ' localip=any remoteip=any protocol=icmpv4:0,any action=block',
          'name=o_good-term-icmp-types enable=yes interfacetype=any dir=out'
@@ -321,7 +321,7 @@ class WindowsAdvFirewallTest(unittest.TestCase):
     self.assertRaises(aclgenerator.UnsupportedFilterError,
                       str, acl)
 
-  @mock.patch.object(windows_advfirewall.logging, 'warn')
+  @mock.patch.object(windows_advfirewall.logging, 'warning')
   def testExpiredTerm(self, mock_warn):
     windows_advfirewall.WindowsAdvFirewall(policy.ParsePolicy(
         GOOD_HEADER_OUT + EXPIRED_TERM, self.naming), EXP_INFO)
@@ -347,7 +347,7 @@ class WindowsAdvFirewallTest(unittest.TestCase):
     acl = windows_advfirewall.WindowsAdvFirewall(policy.ParsePolicy(
         GOOD_HEADER_OUT + MULTIPLE_PROTOCOLS_TERM, self.naming), EXP_INFO)
     result = str(acl)
-    self.FailUnless(
+    self.assertTrue(
         ['name=o_multi-proto enable=yes interfacetype=any dir=out localip=any'
          ' remoteip=any protocol=tcp action=allow',
          'name=o_multi-proto enable=yes interfacetype=any dir=out localip=any'
@@ -362,7 +362,7 @@ class WindowsAdvFirewallTest(unittest.TestCase):
     acl = windows_advfirewall.WindowsAdvFirewall(policy.ParsePolicy(
         GOOD_HEADER_OUT + GOOD_TERM_ANYPROTO, self.naming), EXP_INFO)
     result = str(acl)
-    self.FailUnless(
+    self.assertTrue(
         ['name=o_good-term-anyproto enable=yes interfacetype=any dir=out'
          ' localip=10.0.0.0/8 remoteip=10.0.0.0/8 protocol=any action=allow'],
         result,
@@ -373,7 +373,7 @@ class WindowsAdvFirewallTest(unittest.TestCase):
         GOOD_HEADER_OUT + GOOD_TERM_MISCPROTO + GOOD_TERM_HOPOPT, self.naming),
                                                  EXP_INFO)
     result = str(acl)
-    self.FailUnless(
+    self.assertTrue(
         ['name=o_good-term-miscproto enable=yes interfacetype=any dir=out'
          ' localip=any remoteip=any protocol=112 action=allow',
          'name=o_good-term-hopopt enable=yes interfacetype=any dir=out'

--- a/tests/lib/windows_ipsec_test.py
+++ b/tests/lib/windows_ipsec_test.py
@@ -185,7 +185,7 @@ class WindowsIPSecTest(unittest.TestCase):
         result,
         'good-term-icmp')
 
-  @mock.patch.object(windows_ipsec.logging, 'warn')
+  @mock.patch.object(windows_ipsec.logging, 'warning')
   def testExpiredTerm(self, mock_warn):
     windows_ipsec.WindowsIPSec(policy.ParsePolicy(
         GOOD_HEADER + EXPIRED_TERM, self.naming), EXP_INFO)


### PR DESCRIPTION
When running unit tests, there are many deprecation warnings due to legacy code from python2. This eliminates those warnings so that error messages from tests are more meaningful.