### PR TITLE
Fixed issue #196 for capirca.lib.policy module

### DIFF
--- a/capirca/lib/policy.py
+++ b/capirca/lib/policy.py
@@ -2454,7 +2454,8 @@ def _ReadFile(filename):
   logging.debug('ReadFile(%s)', filename)
   if os.path.exists(filename):
     try:
-      data = open(filename, 'r').read()
+      with open(filename, 'r') as file_handler:
+        data = file_handler.read()
       return data
     except IOError:
       raise FileReadError('Unable to open or read file %s' % filename)


### PR DESCRIPTION
Used context manager to handle file opening and closing appropriately in `capirca.lib.policy` module

fixes #196 