### PR TITLE
Added github actions workflow for branch status

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,23 @@
+name: PyTest
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['3.5', '3.6', '3.7']
+    name: Testing Capirca with python ${{ matrix.python }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install dependencies and script
+        run: pip install -r requirements.txt .
+      - name: Install pytest
+        run: pip install pytest
+      - name: Test with pytest
+        run: pytest tests/


### PR DESCRIPTION
Travis CI is used for testing but there's no branch status associated with the tests that are being run, so only the status of the master branch is known without navigating to the Travis platform.

By adding a github actions workflow file, capirca can be tested on multiple Python versions per commit, with each commit getting a status check flag if the tests pass or fail. Plus, this would allow for pull requests to be verified against the tests to preserve regression before being merged into the codebase