### PR TITLE
Added single-threaded logic

### DIFF
--- a/capirca/aclgen.py
+++ b/capirca/aclgen.py
@@ -106,8 +106,20 @@ def SetupFlags():
       'Raise an error when a term is completely shaded by a prior term.')
   flags.DEFINE_integer(
       'exp_info',
-      2,
+       2,
       'Print a info message when a term is set to expire in that many weeks.')
+  flags.DEFINE_boolean(
+      'profile',
+      False,
+      'Run a thread to profile the execution. Implies \'--max_renderers 1\'')
+  flags.DEFINE_integer(
+      'profile_time',
+      None,
+      'The duration (seconds) that the profile thread should run for. Implies --profile.\n(default: 30)\n(an integer)')
+  flags.DEFINE_string(
+      'pprof_file',
+      None,
+      'The name of the output file for the profile thread. Implies --profile.\n(default:  \'profile.pprof\')')
 
 
 class Error(Exception):
@@ -463,6 +475,19 @@ def _WriteFile(output_file, file_string):
     raise
 
 
+def DiscoverAllPolicies(base_directory, output_directory, definitions):
+  logging.info('finding policies...')
+  pols = []
+  pols.extend(
+    DescendRecursively(
+      base_directory,
+      output_directory,
+      definitions
+    )
+  )
+  return pols
+
+
 def Run(base_directory, definitions_directory, policy_file, output_directory,
         context):
   definitions = None
@@ -482,23 +507,45 @@ def Run(base_directory, definitions_directory, policy_file, output_directory,
     logging.info('rendering one file')
     RenderFile(base_directory, policy_file, output_directory, definitions,
                FLAGS.exp_info, write_files)
+  elif FLAGS.max_renderers == 1:
+    # If only one process, run it sequentially
+    policies = DiscoverAllPolicies(
+      base_directory,
+      output_directory,
+      definitions
+    )
+    for pol in policies:
+      RenderFile(
+        base_directory,
+        pol.get('in_file'),
+        pol.get('out_dir'),
+        definitions,
+        FLAGS.exp_info,
+        write_files
+      )
   else:
     # render all files in parallel
-    logging.info('finding policies...')
-    pols = []
-    pols.extend(DescendRecursively(base_directory, output_directory,
-                                   definitions))
-
+    policies = DiscoverAllPolicies(
+      base_directory,
+      output_directory,
+      definitions
+    )
     pool = context.Pool(processes=FLAGS.max_renderers)
     results = []
-    for x in pols:
-      results.append(pool.apply_async(RenderFile,
-                                      args=(base_directory,
-                                            x.get('in_file'),
-                                            x.get('out_dir'),
-                                            definitions,
-                                            FLAGS.exp_info,
-                                            write_files)))
+    for pol in policies:
+      results.append(
+        pool.apply_async(
+          RenderFile,
+          args=(
+            base_directory,
+            pol.get('in_file'),
+            pol.get('out_dir'),
+            definitions,
+            FLAGS.exp_info,
+            write_files
+          )
+        )
+      )
     pool.close()
     pool.join()
 

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
         'console_scripts': ['aclgen = capirca.aclgen:entry_point'],
     },
     classifiers=[
-                 'Topic :: Security',
-                 'Topic :: System :: Networking :: Firewalls',
-                ],
-    install_requires=['absl-py', 'ply', 'ipaddress>=1.0.22', 'mock', 'six']
+        'Topic :: Security',
+        'Topic :: System :: Networking :: Firewalls',
+    ],
+    install_requires=['absl-py', 'ply', 'ipaddress>=1.0.22', 'mock', 'six'],
 )


### PR DESCRIPTION
When `max_renderers` is set to 1, only a single thread will be running anyways and we can forego the overhead of the multiprocessing pool. Plus, cProfile doesn't play nicely with multiprocessed applications and fails due to a pickling error.