### PR TITLE
Added travis tests that ensure whitespace will fail the PR check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "3.6"
   - "3.7"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install: "pip install -r requirements.txt . && pip install flake8"
 # command to run tests
-script: python -m unittest discover -s . -p '*_test.py'
+script:
+  - python -m unittest discover -s . -p '*_test.py'
+  - flake8 . --count --select=W291,W293,W391 --statistics

--- a/capirca/lib/ciscoasa.py
+++ b/capirca/lib/ciscoasa.py
@@ -365,4 +365,3 @@ class CiscoASA(aclgenerator.ACLGenerator):
 
       # end for header, filter_name, filter_type...
       return '\n'.join(target)
-

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 
-import os
 from setuptools import setup, find_packages
 
 setup(

--- a/tests/lib/aclcheck_test.py
+++ b/tests/lib/aclcheck_test.py
@@ -105,7 +105,7 @@ class AclCheckTest(unittest.TestCase):
     self.assertEqual(matches[0].possibles, [])  # term-1
     self.assertEqual(matches[1].possibles,
                      ['first-frag', 'frag-offset', 'packet-length', 'tcp-est']
-                    )                           # term-2
+                     )                           # term-2
     self.assertEqual(matches[2].possibles, [])  # term-3
 
     # Check which term names match
@@ -132,7 +132,7 @@ class AclCheckTest(unittest.TestCase):
                       bad_portvalue,
                       dport,
                       proto,
-                     )
+                      )
     self.assertRaises(port.BadPortRange,
                       aclcheck.AclCheck,
                       self.pol,
@@ -141,7 +141,7 @@ class AclCheckTest(unittest.TestCase):
                       sport,
                       bad_portrange,
                       proto,
-                     )
+                      )
     self.assertRaises(aclcheck.AddressError,
                       aclcheck.AclCheck,
                       self.pol,
@@ -150,7 +150,7 @@ class AclCheckTest(unittest.TestCase):
                       sport,
                       dport,
                       proto,
-                     )
+                      )
 
 
 if __name__ == '__main__':

--- a/tests/lib/aclgenerator_test.py
+++ b/tests/lib/aclgenerator_test.py
@@ -169,7 +169,7 @@ class ACLGeneratorTest(unittest.TestCase):
                  'ipip': 4,
                  'tcp': 6,
                  'gre': 47,
-                }
+                 }
     proto_convert = ['gre', 'tcp']
 
     protocol_list = ['icmp', 'gre', 'tcp', 'ipip']

--- a/tests/lib/cisco_test.py
+++ b/tests/lib/cisco_test.py
@@ -485,7 +485,7 @@ class CiscoTest(unittest.TestCase):
     # Standard ACLs should have standard remark style.
     acl = cisco.Cisco(policy.ParsePolicy(
         GOOD_STANDARD_NUMBERED_HEADER + GOOD_STANDARD_TERM_1, self.naming),
-                      EXP_INFO)
+        EXP_INFO)
     self.assertIn('access-list 50 remark numbered standard', str(acl),
                   str(acl))
     self.assertIn('access-list 50 remark standard-term-1', str(acl),
@@ -839,6 +839,7 @@ class CiscoTest(unittest.TestCase):
 
     self.naming.GetNetAddr.assert_has_calls([mock.call('cs4-valid_network_name'),
                                              mock.call('cs4-valid_network_name')])
+
   def testNoVerbose(self):
     for i in [GOOD_NOVERBOSE_HEADER, GOOD_NOVERBOSE_STANDARD_HEADER,
               GOOD_NOVERBOSE_OBJGRP_HEADER, GOOD_NOVERBOSE_INET6_HEADER]:
@@ -846,6 +847,7 @@ class CiscoTest(unittest.TestCase):
       acl = cisco.Cisco(policy.ParsePolicy(i+GOOD_STANDARD_TERM_1, self.naming),
                         EXP_INFO)
       self.assertNotIn('remark', str(acl), str(acl))
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/ciscoxr_test.py
+++ b/tests/lib/ciscoxr_test.py
@@ -331,5 +331,6 @@ class CiscoXRTest(unittest.TestCase):
     acl = ciscoxr.CiscoXR(pol, EXP_INFO)
     self.assertIn('permit tcp any', str(acl))
 
+
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/cloudarmor_test.py
+++ b/tests/lib/cloudarmor_test.py
@@ -747,6 +747,6 @@ class CloudArmorTest(unittest.TestCase):
                            self.naming), EXP_INFO)
     self.assertNotIn('description', str(acl))
 
+
 if __name__ == '__main__':
   unittest.main()
-

--- a/tests/lib/gce_test.py
+++ b/tests/lib/gce_test.py
@@ -816,7 +816,7 @@ class GCETest(unittest.TestCase):
     self.naming.GetServiceByProto.side_effect = [['53'], ['53']]
     acl = gce.GCE(policy.ParsePolicy(
         GOOD_HEADER_INGRESS + GOOD_TERM_INGRESS_SOURCETAG, self.naming),
-                  EXP_INFO)
+        EXP_INFO)
 
     self.assertIn('sourceTags', str(acl))
     self.assertNotIn('targetTags', str(acl))
@@ -880,6 +880,7 @@ class GCETest(unittest.TestCase):
                                self.naming)
       acl = gce.GCE(pol, EXP_INFO)
       self.assertIsNotNone(str(acl))
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/gcp_hf_test.py
+++ b/tests/lib/gcp_hf_test.py
@@ -973,5 +973,6 @@ class GcpHfTest(parameterized.TestCase):
 
     self.assertEqual(gcp_hf.GetCost(term), expected)
 
+
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/ipset_test.py
+++ b/tests/lib/ipset_test.py
@@ -329,5 +329,6 @@ class IpsetTest(unittest.TestCase):
     self.assertIn('create -exist', str(acl))
     self.assertIn('add -exist', str(acl))
 
+
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/iptables_test.py
+++ b/tests/lib/iptables_test.py
@@ -874,7 +874,7 @@ class AclCheckTest(unittest.TestCase):
 
     self.assertTrue(re.search(
         '--comment "Text describing with quotes"', result),
-                    'Iptables did not strip out quotes')
+        'Iptables did not strip out quotes')
 
   def testLongTermName(self):
     pol = policy.ParsePolicy(GOOD_HEADER_1 + BAD_LONG_TERM_NAME, self.naming)
@@ -1249,6 +1249,7 @@ class AclCheckTest(unittest.TestCase):
 
     self.assertNotIn('-m u32 --u32 "0x3&0xff=0x0"', result,
                      'match for hop-by-hop header is missing')
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/juniper_test.py
+++ b/tests/lib/juniper_test.py
@@ -692,7 +692,7 @@ class JuniperTest(unittest.TestCase):
         ' ' * 24 + '/* this is a very descriptive comment  this is a\n' +
         ' ' * 24 + '** very descriptive comment  this is a very\n' +
         ' ' * 24 + '** descriptive comment  this is a very descript */'
-        )
+    )
     self.naming.GetNetAddr.return_value = (
         [nacaddr.IPv4('10.0.0.0/8', comment=long_comment)])
     self.naming.GetServiceByProto.return_value = ['25']

--- a/tests/lib/junipersrx_test.py
+++ b/tests/lib/junipersrx_test.py
@@ -698,8 +698,7 @@ class JuniperSRXTest(unittest.TestCase):
 
     # Check the application was split into a set of many applications; 9 terms.
     pattern = re.compile(
-        r'application-set accept-icmpv6-types-app \{\s+(application accept-icmpv6-types-app\d;\s+){9}\}'
-    )
+        r'application-set accept-icmpv6-types-app \{\s+(application accept-icmpv6-types-app\d;\s+){9}\}')
     self.assertTrue(pattern.search(output), output)
 
     # Check that each of the 9 applications with 1 term each.
@@ -714,8 +713,7 @@ class JuniperSRXTest(unittest.TestCase):
 
     # Check for split into application set of many applications; 18 terms.
     pattern = re.compile(
-        r'application-set accept-icmp-types-app \{\s+(application accept-icmp-types-app\d{1,2};\s+){18}\}'
-    )
+        r'application-set accept-icmp-types-app \{\s+(application accept-icmp-types-app\d{1,2};\s+){18}\}')
     self.assertTrue(pattern.search(output), output)
 
     # Check that each of the 18 applications have 1 term each.
@@ -1127,7 +1125,7 @@ class JuniperSRXTest(unittest.TestCase):
     mo_ips = []
     counter = 0
     for ip in ips:
-      if counter%2 == 0:
+      if counter % 2 == 0:
         mo_ips.append(nacaddr.IP(ip))
       counter += 1
 
@@ -1135,7 +1133,7 @@ class JuniperSRXTest(unittest.TestCase):
     prodcolos_ips = []
     counter = 0
     for ip in ips:
-      if counter%2 == 0:
+      if counter % 2 == 0:
         prodcolos_ips.append(nacaddr.IP(ip))
       counter += 1
 
@@ -1153,20 +1151,20 @@ class JuniperSRXTest(unittest.TestCase):
 
   def testLargeTermSplittingV6(self):
     ips = list(nacaddr.IP('2620:0:1000:3103:eca0:2c09:6b32:e000/119'
-                         ).subnets(new_prefix=128))
+                          ).subnets(new_prefix=128))
     mo_ips = []
     counter = 0
     for ip in ips:
-      if counter%2 == 0:
+      if counter % 2 == 0:
         mo_ips.append(nacaddr.IP(ip))
       counter += 1
 
     ips = list(nacaddr.IP('2720:0:1000:3103:eca0:2c09:6b32:e000/119'
-                         ).subnets(new_prefix=128))
+                          ).subnets(new_prefix=128))
     prodcolos_ips = []
     counter = 0
     for ip in ips:
-      if counter%2 == 0:
+      if counter % 2 == 0:
         prodcolos_ips.append(nacaddr.IP(ip))
       counter += 1
 
@@ -1184,21 +1182,21 @@ class JuniperSRXTest(unittest.TestCase):
 
   def testLargeTermSplitIgnoreV6(self):
     ips = list(nacaddr.IP('2620:0:1000:3103:eca0:2c09:6b32:e000/119'
-                         ).subnets(new_prefix=128))
+                          ).subnets(new_prefix=128))
     mo_ips = []
     counter = 0
     for ip in ips:
-      if counter%2 == 0:
+      if counter % 2 == 0:
         mo_ips.append(nacaddr.IP(ip))
       counter += 1
 
     ips = list(nacaddr.IP('2720:0:1000:3103:eca0:2c09:6b32:e000/119'
-                         ).subnets(new_prefix=128))
+                          ).subnets(new_prefix=128))
     ips.append(nacaddr.IPv4('10.0.0.1/32'))
     prodcolos_ips = []
     counter = 0
     for ip in ips:
-      if counter%2 == 0:
+      if counter % 2 == 0:
         prodcolos_ips.append(nacaddr.IP(ip))
       counter += 1
 

--- a/tests/lib/nacaddr_test.py
+++ b/tests/lib/nacaddr_test.py
@@ -158,8 +158,8 @@ class NacaddrUnitTest(unittest.TestCase):
                          expected)
 
   def testAddressListExcludeCaseOne(self):
-  # Small block eliminated by large block, and an extra block that stays.
-  # For both IP versions.
+    # Small block eliminated by large block, and an extra block that stays.
+    # For both IP versions.
     superset = [nacaddr.IPv4('200.0.0.0/24'), nacaddr.IPv4('10.1.0.0/24'),
                 nacaddr.IPv6('200::/56'), nacaddr.IPv6('10:1::/56')]
     excludes = [nacaddr.IPv6('10::/16'), nacaddr.IPv4('10.0.0.0/8')]
@@ -168,7 +168,7 @@ class NacaddrUnitTest(unittest.TestCase):
                          expected)
 
   def testAddressListExcludeCaseTwo(self):
-  # Two blocks out of the middle of a large block.
+    # Two blocks out of the middle of a large block.
     superset = [nacaddr.IPv4('200.0.0.0/24'), nacaddr.IPv4('10.0.0.0/8'),
                 nacaddr.IPv6('200::/56'), nacaddr.IPv6('10::/16')]
     excludes = [nacaddr.IPv6('10:8000::/18'), nacaddr.IPv6('10:4000::/18'),
@@ -181,7 +181,7 @@ class NacaddrUnitTest(unittest.TestCase):
                          expected)
 
   def testAddressListExcludeCaseThree(self):
-  # Two blocks off both ends of a large block.
+    # Two blocks off both ends of a large block.
     superset = [nacaddr.IPv4('200.0.0.0/24'), nacaddr.IPv4('10.0.0.0/8'),
                 nacaddr.IPv6('200::/56'), nacaddr.IPv6('10::/16')]
     excludes = [nacaddr.IPv6('10::/18'), nacaddr.IPv6('10:c000::/18'),
@@ -194,7 +194,7 @@ class NacaddrUnitTest(unittest.TestCase):
                          expected)
 
   def testAddressListExcludeCaseFour(self):
-  # IPv6 does not affect IPv4
+    # IPv6 does not affect IPv4
     superset = [nacaddr.IPv4('0.0.0.0/0')]
     excludes = [nacaddr.IPv6('::/0')]
     expected = [nacaddr.IPv4('0.0.0.0/0')]
@@ -202,7 +202,7 @@ class NacaddrUnitTest(unittest.TestCase):
                          expected)
 
   def testAddressListExcludeCaseFive(self):
-  # IPv6 does not affect IPv4
+    # IPv6 does not affect IPv4
     superset = [nacaddr.IPv6('::/0')]
     excludes = [nacaddr.IPv4('0.0.0.0/0')]
     expected = [nacaddr.IPv6('::/0')]
@@ -210,7 +210,7 @@ class NacaddrUnitTest(unittest.TestCase):
                          expected)
 
   def testAddressListExcludeCaseSix(self):
-  # IPv6 does not affect IPv4
+    # IPv6 does not affect IPv4
     superset = [nacaddr.IPv6('0::ffff:0.0.0.0/96')]
     excludes = [nacaddr.IPv4('0.0.0.0/0')]
     expected = [nacaddr.IPv6('0::ffff:0.0.0.0/96')]
@@ -229,13 +229,13 @@ class NacaddrUnitTest(unittest.TestCase):
                  nacaddr.IPv4('192.168.1.7/31',
                               token='UNDERSUPER',
                               strict=False)
-                ]
+                 ]
     expected = [nacaddr.IPv4('10.0.0.7/32', token='BAR'),
                 nacaddr.IPv4('10.0.0.9/32', token='BAR'),
                 nacaddr.IPv4('10.0.1.6/31', token='BIZ'),
                 nacaddr.IPv4('10.0.0.6/32', token='FOO'),
                 nacaddr.IPv4('10.0.0.8/32', token='FOO'),
-                nacaddr.IPv4('192.168.1.1/24', token='SUPER', strict=False),]
+                nacaddr.IPv4('192.168.1.1/24', token='SUPER', strict=False), ]
     collapsed = nacaddr.CollapseAddrListPreserveTokens(addr_list)
     self.assertListEqual(collapsed, expected)
 
@@ -274,7 +274,7 @@ class NacaddrUnitTest(unittest.TestCase):
                    nacaddr.IPv6('10::/56')],
                   [nacaddr.IPv6('8::/64')],
                   [nacaddr.IPv6('10::/56')])
-                ]
+                 ]
     for addresses, complement_addresses, result in test_data:
       self.assertEqual(nacaddr.CollapseAddrList(addresses,
                                                 complement_addresses), result)

--- a/tests/lib/naming_test.py
+++ b/tests/lib/naming_test.py
@@ -195,5 +195,6 @@ class NamingUnitTest(unittest.TestCase):
   def testGetNetChildrenNoChild(self):
     self.assertEqual([], self.defs.GetNetChildren('NET1'))
 
+
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/nftables_test.py
+++ b/tests/lib/nftables_test.py
@@ -469,7 +469,7 @@ class NftablesTest(unittest.TestCase):
         'Term %s in policy is too long (>%d characters) and will be'
         ' truncated', 'good-term-17', nftables.Term.MAX_CHARACTERS)
     # Ensure that the truncate did happen and stripped off the ':'
-    self.assertIn('comment "%(long_line)s' % {'long_line': 'A' *127}, nft)
+    self.assertIn('comment "%(long_line)s' % {'long_line': 'A' * 127}, nft)
 
   def testLogTerm(self):
     nft = str(nftables.Nftables(policy.ParsePolicy(GOOD_HEADER_1 + GOOD_TERM_13,

--- a/tests/lib/nsxv_functtest.py
+++ b/tests/lib/nsxv_functtest.py
@@ -42,7 +42,7 @@ class NsxvFunctionalTest(unittest.TestCase):
     """
     _parser = OptionParser()
     _parser.add_option('-d', '--def', dest='definitions',
-                      help='definitions directory', default='../def')
+                       help='definitions directory', default='../def')
     (FLAGS, args) = _parser.parse_args()
     self.defs = naming.Naming(FLAGS.definitions)
 
@@ -61,14 +61,14 @@ class NsxvFunctionalTest(unittest.TestCase):
 
     # parse the xml
     root = ET.fromstring(output)
-     # check section name
+    # check section name
     section_name = {'id': '1007', 'name': 'POLICY_NAME'}
     self.assertEqual(root.attrib, section_name)
     # check name and action
     self.assertEqual(root.find('./rule/name').text, 'reject-imap-requests')
     self.assertEqual(root.find('./rule/action').text, 'reject')
 
-    #check IPV4 destination
+    # check IPV4 destination
     exp_destaddr = ['200.1.1.4/31']
 
     for destination in root.findall('./rule/destinations/destination'):
@@ -77,8 +77,8 @@ class NsxvFunctionalTest(unittest.TestCase):
       if value not in exp_destaddr:
         self.fail('IPv4Address destination not found in test_nsxv_str()')
 
-    #check protocol
-    protocol =  int(root.find('./rule/services/service/protocol').text)
+    # check protocol
+    protocol = int(root.find('./rule/services/service/protocol').text)
     self.assertEqual(protocol, 6)
 
     # check destination port
@@ -93,15 +93,15 @@ class NsxvFunctionalTest(unittest.TestCase):
     output = str(fw)
     # parse the xml
     root = ET.fromstring(output)
-     # check section name
+    # check section name
     section_name = {'name': 'POLICY_NO_SECTION_ID_NAME'}
     self.assertEqual(root.attrib, section_name)
     # check name and action
     self.assertEqual(root.find('./rule/name').text, 'accept-icmp')
     self.assertEqual(root.find('./rule/action').text, 'allow')
 
-    #check protocol
-    protocol =  int(root.find('./rule/services/service/protocol').text)
+    # check protocol
+    protocol = int(root.find('./rule/services/service/protocol').text)
     self.assertEqual(protocol, 1)
 
   def test_nsxv_nofiltertype(self):

--- a/tests/lib/nsxv_test.py
+++ b/tests/lib/nsxv_test.py
@@ -995,5 +995,6 @@ class TermTest(unittest.TestCase):
     self.assertTrue(ipv4_address)
     self.assertTrue(ipv6_address)
 
+
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/nsxv_unittest.py
+++ b/tests/lib/nsxv_unittest.py
@@ -35,7 +35,7 @@ class TermTest(unittest.TestCase):
     """Call before every test case."""
     _parser = OptionParser()
     _parser.add_option('-d', '--def', dest='definitions',
-                      help='definitions directory', default='../def')
+                       help='definitions directory', default='../def')
     (FLAGS, args) = _parser.parse_args()
     self.defs = naming.Naming(FLAGS.definitions)
 
@@ -66,14 +66,16 @@ class TermTest(unittest.TestCase):
     spots = [(123, 123)]
     nsxv_term = nsxv.Term(nsxv_mocktest.INET_TERM, 'inet')
     service = nsxv_term._ServiceToString(proto, spots, dports, icmp_types)
-    self.assertEquals(service, '<service><protocol>6</protocol><sourcePort>123</sourcePort><destinationPort>1024-65535</destinationPort></service>')
+    self.assertEquals(
+        service,
+        '<service><protocol>6</protocol><sourcePort>123</sourcePort><destinationPort>1024-65535</destinationPort></service>')
 
   def test_str_forinet(self):
     """ Test for Term._str_ """
     pol = policy.ParsePolicy(nsxv_mocktest.INET_FILTER, self.defs, False)
-    af=4
+    af = 4
     for header, terms in pol.filters:
-       nsxv_term= nsxv.Term(terms[0], af)
+       nsxv_term = nsxv.Term(terms[0], af)
        rule_str = nsxv.Term.__str__(nsxv_term)
     # parse xml rule and check if the values are correct
     root = ET.fromstring(rule_str)
@@ -81,27 +83,27 @@ class TermTest(unittest.TestCase):
     self.assertEqual(root.find('name').text, 'allow-ntp-request')
     self.assertEqual(root.find('action').text, 'allow')
 
-    #check source address
-    exp_sourceaddr = ['10.0.0.1','10.0.0.2']
+    # check source address
+    exp_sourceaddr = ['10.0.0.1', '10.0.0.2']
     for destination in root.findall('./sources/source'):
       self.assertEqual((destination.find('type').text), 'Ipv4Address')
       value = (destination.find('value').text)
       if value not in exp_sourceaddr:
         self.fail('IPv4Address source address not found in test_str_forinet()')
 
-    #check destination address
-    exp_destaddr = ['10.0.0.0/8','172.16.0.0/12','192.168.0.0/16']
+    # check destination address
+    exp_destaddr = ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16']
     for destination in root.findall('./destinations/destination'):
       self.assertEqual((destination.find('type').text), 'Ipv4Address')
       value = (destination.find('value').text)
       if value not in exp_destaddr:
         self.fail('IPv4Address destination not found in test_str_forinet()')
 
-    #check protocol
-    protocol =  int(root.find('./services/service/protocol').text)
+    # check protocol
+    protocol = int(root.find('./services/service/protocol').text)
     self.assertEqual(protocol, 17)
 
-    #check source port
+    # check source port
     source_port = root.find('./services/service/sourcePort').text
     self.assertEqual(source_port, '123')
 
@@ -110,16 +112,16 @@ class TermTest(unittest.TestCase):
     self.assertEqual(destination_port, '123')
 
     # check notes
-    notes =  root.find('notes').text
+    notes = root.find('notes').text
     self.assertEqual(notes, 'Allow ntp request')
 
   def test_str_forinet6(self):
     """ Test for Term._str_ """
     pol = policy.ParsePolicy(nsxv_mocktest.INET6_FILTER, self.defs, False)
-    af=6
+    af = 6
     filter_type = 'inet6'
     for header, terms in pol.filters:
-       nsxv_term= nsxv.Term(terms[0], filter_type, af)
+       nsxv_term = nsxv.Term(terms[0], filter_type, af)
        rule_str = nsxv.Term.__str__(nsxv_term)
 
     # parse xml rule and check if the values are correct
@@ -128,7 +130,7 @@ class TermTest(unittest.TestCase):
     self.assertEqual(root.find('name').text, 'test-icmpv6')
     self.assertEqual(root.find('action').text, 'allow')
 
-    #check protocol and sub protocol
+    # check protocol and sub protocol
     exp_subprotocol = [128, 129]
     for service in root.findall('./services/service'):
       protocol = int(service.find('protocol').text)
@@ -146,10 +148,10 @@ class TermTest(unittest.TestCase):
     translate_pol = nsxv.Nsxv(pol, exp_info)
     nsxv_policies = translate_pol.nsxv_policies
     for (header, filter_name, filter_list, terms
-        ) in nsxv_policies:
+         ) in nsxv_policies:
       self.assertEqual(filter_name, 'inet')
       self.assertEqual(filter_list, ['inet'])
-      self.assertEqual(len(terms) , 1)
+      self.assertEqual(len(terms), 1)
 
   def test_nsxv_str(self):
     """ Test for Nsxv._str_ """
@@ -158,7 +160,7 @@ class TermTest(unittest.TestCase):
     pol = policy.ParsePolicy(nsxv_mocktest.MIXED_FILTER, self.defs, False)
     target = nsxv.Nsxv(pol, exp_info)
 
-    #parse the xml and check the values
+    # parse the xml and check the values
     root = ET.fromstring(str(target))
     # check section name
     section_name = {'id': '1009', 'name': 'MIXED_FILTER_NAME'}
@@ -167,9 +169,9 @@ class TermTest(unittest.TestCase):
     self.assertEqual(root.find('./rule/name').text, 'accept-to-honestdns')
     self.assertEqual(root.find('./rule/action').text, 'allow')
 
-    #check IPV4 and IPV6 destinations
-    exp_ipv4dest = ['8.8.4.4','8.8.8.8']
-    exp_ipv6dest = ['2001:4860:4860::8844','2001:4860:4860::8888']
+    # check IPV4 and IPV6 destinations
+    exp_ipv4dest = ['8.8.4.4', '8.8.8.8']
+    exp_ipv6dest = ['2001:4860:4860::8844', '2001:4860:4860::8888']
 
     for destination in root.findall('./rule/destinations/destination'):
       type = destination.find('type').text
@@ -182,8 +184,8 @@ class TermTest(unittest.TestCase):
         if value not in exp_ipv6dest:
           self.fail('IPv6Address not found in test_nsxv_str()')
 
-    #check protocol
-    protocol =  int(root.find('./rule/services/service/protocol').text)
+    # check protocol
+    protocol = int(root.find('./rule/services/service/protocol').text)
     self.assertEqual(protocol, 17)
 
     # check destination port
@@ -191,7 +193,7 @@ class TermTest(unittest.TestCase):
     self.assertEqual(destination_port, '53')
 
     # check notes
-    notes =  root.find('./rule/notes').text
+    notes = root.find('./rule/notes').text
     self.assertEqual(notes, 'Allow name resolution using honestdns.')
 
   if __name__ == '__main__':

--- a/tests/lib/packetfilter_test.py
+++ b/tests/lib/packetfilter_test.py
@@ -418,8 +418,7 @@ class PacketFilterTest(unittest.TestCase):
                   'did not find comment for good-term-log')
     self.assertIn(
         'pass quick log proto { tcp } from { any } to { any } flags S/SA '
-        'keep state\n'
-        , result,
+        'keep state\n', result,
         'did not find actual term for good-term-log')
 
   def testIcmp(self):
@@ -429,8 +428,7 @@ class PacketFilterTest(unittest.TestCase):
     self.assertIn('# term good-term-icmp', result,
                   'did not find comment for good-term-icmp')
     self.assertIn(
-        'pass quick proto { icmp } from { any } to { any } keep state\n'
-        , result,
+        'pass quick proto { icmp } from { any } to { any } keep state\n', result,
         'did not find actual term for good-term-icmp')
 
   def testIcmpTypes(self):
@@ -451,8 +449,7 @@ class PacketFilterTest(unittest.TestCase):
     self.assertIn('# term good-term-icmpv6', result,
                   'did not find comment for good-term-icmpv6')
     self.assertIn(
-        'pass quick proto { ipv6-icmp } from { any } to { any } keep state\n'
-        , result,
+        'pass quick proto { ipv6-icmp } from { any } to { any } keep state\n', result,
         'did not find actual term for good-term-icmpv6')
 
   def testBadIcmp(self):
@@ -499,8 +496,7 @@ class PacketFilterTest(unittest.TestCase):
     self.assertIn('# term multi-proto', result,
                   'did not find comment for multi-proto')
     self.assertIn(
-        'pass quick proto { tcp udp icmp } from { any } to { any } keep state\n'
-        , result,
+        'pass quick proto { tcp udp icmp } from { any } to { any } keep state\n', result,
         'did not find actual term for multi-proto')
 
   def testNextTerm(self):
@@ -591,8 +587,7 @@ class PacketFilterTest(unittest.TestCase):
                   'did not find comment for good-term-log')
     self.assertIn(
         'pass quick log inet proto { tcp } from { any } to { any } flags S/SA '
-        'keep state\n'
-        , result,
+        'keep state\n', result,
         'did not find actual term for good-term-log')
 
   def testInet6(self):
@@ -603,8 +598,7 @@ class PacketFilterTest(unittest.TestCase):
                   'did not find comment for good-term-log')
     self.assertIn(
         'pass quick log inet6 proto { tcp } from { any } to { any } flags S/SA '
-        'keep state\n'
-        , result,
+        'keep state\n', result,
         'did not find actual term for good-term-log')
 
   def testDirectional(self):
@@ -649,7 +643,7 @@ class PacketFilterTest(unittest.TestCase):
 
     acl = packetfilter.PacketFilter(policy.ParsePolicy(
         GOOD_HEADER_DIRECTIONAL_STATELESS + GOOD_TERM_TCP, self.naming),
-                                    EXP_INFO)
+        EXP_INFO)
     result = str(acl)
     self.assertIn('# term good-term-tcp', result,
                   'did not find comment for good-term-tcp')
@@ -664,7 +658,7 @@ class PacketFilterTest(unittest.TestCase):
   def testStatelessEstablished(self):
     acl = packetfilter.PacketFilter(policy.ParsePolicy(
         GOOD_HEADER_STATELESS + TCP_STATE_TERM, self.naming),
-                                    EXP_INFO)
+        EXP_INFO)
     result = str(acl)
     self.assertIn('# term tcp-established-only', result,
                   'did not find comment for tcp-established-only')
@@ -693,7 +687,7 @@ class PacketFilterTest(unittest.TestCase):
   def testUdpStatelessEstablished(self):
     acl = packetfilter.PacketFilter(policy.ParsePolicy(
         GOOD_HEADER_STATELESS + UDP_ESTABLISHED_TERM, self.naming),
-                                    EXP_INFO)
+        EXP_INFO)
     result = str(acl)
     self.assertIn('# term udp-established', result,
                   'did not find comment for udp-established')
@@ -716,7 +710,7 @@ class PacketFilterTest(unittest.TestCase):
   def testTcpEstablished(self):
     acl = packetfilter.PacketFilter(policy.ParsePolicy(
         GOOD_HEADER + TCP_GOOD_ESTABLISHED_TERM, self.naming),
-                                    EXP_INFO)
+        EXP_INFO)
     result = str(acl)
     self.assertIn('# term tcp-established-good', result,
                   'did not find comment for tcp-established-good')
@@ -739,7 +733,7 @@ class PacketFilterTest(unittest.TestCase):
 
     acl = packetfilter.PacketFilter(policy.ParsePolicy(
         GOOD_HEADER + MULTIPLE_NAME_TERM, self.naming),
-                                    EXP_INFO)
+        EXP_INFO)
     result = str(acl)
     self.assertIn(
         'table <PROD_NETWORK> {10.0.0.0/8}', result,
@@ -750,8 +744,7 @@ class PacketFilterTest(unittest.TestCase):
         'did not find CORP_INTERNAL table in header')
     self.assertIn(
         'pass quick proto { tcp } from { <CORP_INTERNAL> } to '
-        '{ <PROD_NETWORK> } port { 25 } flags S/SA keep state'
-        , result,
+        '{ <PROD_NETWORK> } port { 25 } flags S/SA keep state', result,
         'did not find actual term for multiple-name')
 
     self.naming.GetNetAddr.assert_has_calls([
@@ -775,8 +768,7 @@ class PacketFilterTest(unittest.TestCase):
     self.assertIn(
         'pass out quick proto { tcp } from { any } to '
         '{ <PROD_NETWORK_EXTREAMLY_LONG_VER> } '
-        'port { 53 } flags S/SA keep state'
-        , result,
+        'port { 53 } flags S/SA keep state', result,
         'did not find actual term for multiple-name')
 
     self.naming.GetNetAddr.assert_called_once_with(
@@ -822,14 +814,12 @@ class PacketFilterTest(unittest.TestCase):
     self.assertIn(
         'pass out quick proto { tcp } from { any } to '
         '{ <PROD_NETWORK_EXTREAMLY_LONG_VER> } '
-        'port { 53 } flags S/SA keep state'
-        , result,
+        'port { 53 } flags S/SA keep state', result,
         'did not find actual TCP term for multiple-name')
     self.assertIn(
         'pass out quick proto { udp } from { any } to '
         '{ <PROD_NETWORK_EXTREAMLY_LONG_VER> } '
-        'port { 53 } keep state'
-        , result,
+        'port { 53 } keep state', result,
         'did not find actual UDP for multiple-name')
 
     self.naming.GetNetAddr.assert_has_calls([
@@ -856,14 +846,12 @@ class PacketFilterTest(unittest.TestCase):
     self.assertIn(
         'pass out quick proto { tcp } from { any } to '
         '{ <PROD_NETWORK_EXTREAMLY_LONG_VER> } '
-        'port { 53 } flags S/SA keep state'
-        , result,
+        'port { 53 } flags S/SA keep state', result,
         'did not find actual TCP term for multiple-name')
     self.assertIn(
         'pass out quick proto { udp } from { any } to '
         '{ <PROD_NETWORK_EXTREAMLY_LONG_VER> } '
-        'port { 53 } keep state'
-        , result,
+        'port { 53 } keep state', result,
         'did not find actual UDP for multiple-name')
 
     self.naming.GetNetAddr.assert_has_calls([

--- a/tests/lib/paloaltofw_test.py
+++ b/tests/lib/paloaltofw_test.py
@@ -225,7 +225,7 @@ class PaloAltoFWTest(unittest.TestCase):
     self.naming.GetServiceByProto.return_value = ['25']
 
     paloalto = paloaltofw.PaloAltoFW(
-        policy.ParsePolicy(GOOD_HEADER_1 +GOOD_TERM_1,
+        policy.ParsePolicy(GOOD_HEADER_1 + GOOD_TERM_1,
                            self.naming), EXP_INFO)
     output = str(paloalto)
     self.assertIn('<entry name="good-term-1">', output, output)
@@ -262,6 +262,7 @@ class PaloAltoFWTest(unittest.TestCase):
     st, sst = pol1._BuildTokens()
     self.assertEqual(st, SUPPORTED_TOKENS)
     self.assertEqual(sst, SUPPORTED_SUB_TOKENS)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/policy_simple_test.py
+++ b/tests/lib/policy_simple_test.py
@@ -24,7 +24,6 @@ from capirca.lib import policy_simple
 from six.moves import range
 
 
-
 class FieldTest(unittest.TestCase):
 
   def setUp(self):

--- a/tests/lib/policy_test.py
+++ b/tests/lib/policy_test.py
@@ -1674,5 +1674,6 @@ class PolicyTest(unittest.TestCase):
                                  ('proj3', 'vpc3'), ('proj4', 'vpc4')]
     self.assertListEqual(expected_target_resources, terms[0].target_resources)
 
+
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/srxlo_test.py
+++ b/tests/lib/srxlo_test.py
@@ -206,5 +206,6 @@ class SRXloTest(unittest.TestCase):
                                                 self.naming), EXP_INFO))
     self.assertIn('inactive: term good-term-3 {', output)
 
+
 if __name__ == '__main__':
   unittest.main()

--- a/tests/lib/summarizer_test.py
+++ b/tests/lib/summarizer_test.py
@@ -44,9 +44,9 @@ class SummarizerTest(unittest.TestCase):
     random.seed(random_seed)
 
   def testToDottedQuad(self):
-    net = summarizer.DSMNet(1<<32, 4294967264)
+    net = summarizer.DSMNet(1 << 32, 4294967264)
     self.assertRaises(ValueError)
-    net = summarizer.DSMNet(3232235584, 1<<16)
+    net = summarizer.DSMNet(3232235584, 1 << 16)
     self.assertRaises(ValueError)
     net = summarizer.DSMNet(3232235584, 4294967264)
     self.assertEqual(summarizer.ToDottedQuad(net),
@@ -171,7 +171,7 @@ class SummarizerTest(unittest.TestCase):
                               summarizer.DSMNet(3232249888, 4294966398),
                               summarizer.DSMNet(3232249908, 4294966398),
                               summarizer.DSMNet(3232249942, 4294966398),
-                             ])
+                              ])
 
   def testMergeText(self):
     existing_comment = 'comment that already exists'
@@ -198,9 +198,8 @@ class SummarizerTest(unittest.TestCase):
     result = summarizer.Summarize(nets)
     self.assertEqual(result, [summarizer.DSMNet(1249711233, 4294967039),
                               summarizer.DSMNet(3512046465, 4294967295)
-                             ])
+                              ])
 
 
 if __name__ == '__main__':
   unittest.main()
-

--- a/tests/lib/windows_advfirewall_test.py
+++ b/tests/lib/windows_advfirewall_test.py
@@ -371,13 +371,13 @@ class WindowsAdvFirewallTest(unittest.TestCase):
   def testMiscProtocol(self):
     acl = windows_advfirewall.WindowsAdvFirewall(policy.ParsePolicy(
         GOOD_HEADER_OUT + GOOD_TERM_MISCPROTO + GOOD_TERM_HOPOPT, self.naming),
-                                                 EXP_INFO)
+        EXP_INFO)
     result = str(acl)
     self.assertTrue(
         ['name=o_good-term-miscproto enable=yes interfacetype=any dir=out'
          ' localip=any remoteip=any protocol=112 action=allow',
          'name=o_good-term-hopopt enable=yes interfacetype=any dir=out'
-         ' localip=any remoteip=any protocol=0 action=allow',],
+         ' localip=any remoteip=any protocol=0 action=allow', ],
         result,
         'explicit miscellaneous proto')
 

--- a/tests/lib/windows_test.py
+++ b/tests/lib/windows_test.py
@@ -180,5 +180,6 @@ class WindowsGeneratorTest(unittest.TestCase):
         GOOD_HEADER + UDP_ESTABLISHED_TERM + GOOD_TERM, self.naming), EXP_INFO)
     self.assertEqual(len(pol.windows_policies[0][4]), 1)
 
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
To avoid having PRs refused because they do not pass the whitespace check at the copybara step, adding it to the travis step will allow early reporting of invalid PRs.

To also make sure that the current project doesn't fail those checks, autopep8 was used to fix some linting issues. The commands used were:

```bash
$ autopep8 --ignore E226,E24,W50,W690,E111,E114,W191,E101 --max-line-length 100 --in-place --aggressive --aggressive --recursive capirca
$ autopep8 --ignore E226,E24,W50,W690,E111,E114,W191,E101 --max-line-length 100 --in-place --aggressive --aggressive --recursive tests
```