### PR TITLE
chg: faster creation/copying of IP objects when they receive an IP object constructor

### DIFF
--- a/capirca/lib/nacaddr.py
+++ b/capirca/lib/nacaddr.py
@@ -71,7 +71,14 @@ class IPv4(ipaddress.IPv4Network):
     self.text = comment
     self.token = token
     self.parent_token = token
-    super(IPv4, self).__init__(ip_string, strict)
+
+    # Using a tuple of IP integer/prefixlength is significantly faster than
+    # using the BaseNetwork object for recreating the IP network
+    if isinstance(ip_string, ipaddress._BaseNetwork):  # pylint disable=protected-access
+      ip = (ip_string.network_address._ip, ip_string.prefixlen)  # pylint disable=protected-access
+    else:
+      ip = ip_string
+    super(IPv4, self).__init__(ip, strict)
 
   def subnet_of(self, other):
     """Return True if this network is a subnet of other."""
@@ -86,7 +93,7 @@ class IPv4(ipaddress.IPv4Network):
     return self._is_subnet_of(other, self)
 
   def __deepcopy__(self, memo):
-    result = self.__class__(self.with_prefixlen)
+    result = self.__class__(self)
     result.text = self.text
     result.token = self.token
     result.parent_token = self.parent_token
@@ -143,7 +150,14 @@ class IPv6(ipaddress.IPv6Network):
     self.text = comment
     self.token = token
     self.parent_token = token
-    super(IPv6, self).__init__(ip_string, strict)
+
+    # Using a tuple of IP integer/prefixlength is significantly faster than
+    # using the BaseNetwork object for recreating the IP network
+    if isinstance(ip_string, ipaddress._BaseNetwork):  # pylint disable=protected-access
+      ip = (ip_string.network_address._ip, ip_string.prefixlen)  # pylint disable=protected-access
+    else:
+      ip = ip_string
+    super(IPv6, self).__init__(ip, strict)
 
   def subnet_of(self, other):
     """Return True if this network is a subnet of other."""
@@ -158,7 +172,7 @@ class IPv6(ipaddress.IPv6Network):
     return self._is_subnet_of(other, self)
 
   def __deepcopy__(self, memo):
-    result = self.__class__(self.with_prefixlen)
+    result = self.__class__(self)
     result.text = self.text
     result.token = self.token
     result.parent_token = self.parent_token


### PR DESCRIPTION
A lot of time is spent recreating the IP objects when performing address list exclusion. By extracting the IP integer and prefixlen from the object, we can use the parent constructor more efficiently (since this tuple is the fastest way of creating the IP network object in `ipaddress`).

This could instead be done by just copying the parameters to the internal instead, which would be a 4x performance boost (according to `timeit`), but as it stands this is already a significant boost.

```python
>>> import ipaddress
>>> class IPv4(ipaddress.IPv4Network):
...     def __init__(self, ip_str):
...             if isinstance(ip_str, ipaddress._BaseNetwork):
...                     self.network_address = ip_str.network_address
...                     self._prefixlen = ip_str._prefixlen
...                     self._cache = ip_str._cache
...                     self.netmask = ip_str.netmask
...                     self.hosts = ip_str.hosts
...             else:
...                     super(IPv4, self).__init__(ip_str)
>>> class IPv4NoCopy(ipaddress.IPv4Network):
...     def __init__(self, ip_str):
...             super(IPv4NoCopy, self).__init__(ip_str)
>>> class IPv4Tuple(ipaddress.IPv4Network):
...     def __init__(self, ip_str):
...             if isinstance(ip_str, ipaddress._BaseNetwork):
...                     ip = (ip_str.network_address._ip, ip_str.prefixlen)
...             else:
...                     ip = ip_str
...             super(IPv4Tuple, self).__init__(ip)
>>> i = ipaddress.ip_network('192.168.0.0/24')
>>> from timeit import timeit
>>> timeit(lambda: IPv4NoCopy(i))
7.518763416970614
>>> timeit(lambda: IPv4Tuple(i))
2.1849999999976717
>>> timeit(lambda: IPv4(i))
0.583199410000816
```