### PR TITLE
new: added file-base configuration for capirca

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,31 @@ To install the dev environment in machines that support bash files, run the `dev
 $ dev-install
 ```
 
+
+## Configuring Capirca with YAML files
+Capirca's `aclgen` can be configured with one or more yaml files. These files will be prioritized from left to right, meaning any duplicate configurations will be overriden, not merged.
+
+Command line flags can still be used when running `aclgen` with configuration files, and are treated as higher priority than configuration files.
+
+The default capirca configurations for `aclgen` can be expressed in a YAML file as follows:
+
+```yaml
+base_directory: ./policies
+definitions_directory: ./def
+output_directory: ./
+optimize: false
+recursive: true
+debug: false
+verbose: false
+ignore_directories:
+  - DEPRECATED
+  - def
+max_renderers: 10
+shade_check: true
+exp_info: 2
+```
+
+
 ## Community
 Capirca has a channel on the [NetworkToCode slack](https://networktocode.slack.com/).
 

--- a/capirca/aclgen.py
+++ b/capirca/aclgen.py
@@ -116,8 +116,13 @@ def SetupFlags():
     % str(config.defaults['shade_check']).lower())
   flags.DEFINE_integer(
     'exp_info',
-    2,
-    'Print a info message when a term is set to expire in that many weeks.')
+    None,
+    'Print a info message when a term is set to expire in that many weeks.\n(default: \'%s\')'
+    % str(config.defaults['exp_info']))
+  flags.DEFINE_multi_string(
+    'config_file',
+    None,
+    'A yaml file with the configuration options for capirca')
 
 
 class Error(Exception):

--- a/capirca/aclgen.py
+++ b/capirca/aclgen.py
@@ -54,75 +54,70 @@ from capirca.lib import speedway
 from capirca.lib import srxlo
 from capirca.lib import windows_advfirewall
 
+from capirca.utils import config
+
 
 FLAGS = flags.FLAGS
 
 
 def SetupFlags():
   flags.DEFINE_string(
-      'base_directory',
-      './policies',
-      'The base directory to look for acls; '
-      'typically where you\'d find ./corp and ./prod')
+    'base_directory',
+    None,
+    'The base directory to look for acls; '
+    'typically where you\'d find ./corp and ./prod\n(default: \'%s\')'
+    % config.defaults['base_directory'])
   flags.DEFINE_string(
-      'definitions_directory',
-      './def',
-      'Directory where the definitions can be found.')
+    'definitions_directory',
+    None,
+    'Directory where the definitions can be found.\n(default: \'%s\')'
+    % config.defaults['definitions_directory'])
   flags.DEFINE_string(
-      'policy_file',
-      None,
-      'Individual policy file to generate.')
+    'policy_file',
+    None,
+    'Individual policy file to generate.')
   flags.DEFINE_string(
-      'output_directory',
-      './',
-      'Directory to output the rendered acls.')
+    'output_directory',
+    None,
+    'Directory to output the rendered acls.\n(default: \'%s\')'
+    % config.defaults['output_directory'])
   flags.DEFINE_boolean(
-      'optimize',
-      False,
-      'Turn on optimization.',
-      short_name='o')
+    'optimize',
+    None,
+    'Turn on optimization.\n(default: \'%s\')' % config.defaults['optimize'],
+    short_name='o')
   flags.DEFINE_boolean(
-      'recursive',
-      True,
-      'Descend recursively from the base directory rendering acls')
+    'recursive',
+    None,
+    'Descend recursively from the base directory rendering acls\n(default: \'%s\')'
+    % str(config.defaults['recursive']).lower())
   flags.DEFINE_boolean(
-      'debug',
-      False,
-      'Debug messages')
+    'debug',
+    None,
+    'Debug messages\n(default: \'%s\')' % str(config.defaults['debug']).lower())
   flags.DEFINE_boolean(
-      'verbose',
-      False,
-      'Verbose messages')
+    'verbose',
+    None,
+    'Verbose messages\n(default: \'%s\')' % str(config.defaults['verbose']).lower())
   flags.DEFINE_list(
-      'ignore_directories',
-      'DEPRECATED, def',
-      'Don\'t descend into directories that look like this string')
+    'ignore_directories',
+    None,
+    'Don\'t descend into directories that look like this string\n(default: \'%s\')'
+    % ",".join(config.defaults['ignore_directories']))
   flags.DEFINE_integer(
-      'max_renderers',
-      10,
-      'Max number of rendering processes to use.')
+    'max_renderers',
+    None,
+    'Max number of rendering processes to use.\n(default: \'%s\')'
+    % config.defaults['max_renderers'])
   flags.DEFINE_boolean(
-      'shade_check',
-      False,
-      'Raise an error when a term is completely shaded by a prior term.')
+    'shade_check',
+    None,
+    'Raise an error when a term is completely shaded by a prior term.\n(default: \'%s\')'
+    % str(config.defaults['shade_check']).lower())
   flags.DEFINE_integer(
-      'exp_info',
-      2,
-      'Print a info message when a term is set to expire in that many weeks.')
-  flags.DEFINE_boolean(
-      'profile',
-      False,
-      'Run a thread to profile the execution. Implies \'--max_renderers 1\'')
-  flags.DEFINE_integer(
-      'profile_time',
-      None,
-      'The duration (seconds) that the profile thread should run for. '
-      'Implies --profile.\n(default: 30)\n(an integer)')
-  flags.DEFINE_string(
-      'pprof_file',
-      None,
-      'The name of the output file for the profile thread. Implies --profile.\n'
-      '(default:  \'profile.pprof\')')
+    'exp_info',
+    2,
+    'Print a info message when a term is set to expire in that many weeks.')
 
 
 class Error(Exception):
@@ -410,7 +405,7 @@ def FilesUpdated(file_name, new_text, binary):
   return conf != new_text
 
 
-def DescendRecursively(input_dirname, output_dirname, definitions, depth=1):
+def DescendRecursively(input_dirname, output_dirname, definitions, ignore_directories, depth=1):
   """Recursively descend from input_dirname looking for policy files to render.
 
   Args:
@@ -434,19 +429,24 @@ def DescendRecursively(input_dirname, output_dirname, definitions, depth=1):
     if curdir == 'pol':
       for input_file in [x for x in os.listdir(input_dirname + '/pol')
                          if x.endswith('.pol')]:
-        files.append({'in_file': os.path.join(input_dirname, 'pol', input_file),
-                      'out_dir': output_dirname,
-                      'defs': definitions})
+        files.append({
+          'in_file': os.path.join(input_dirname, 'pol', input_file),
+          'out_dir': output_dirname,
+          'defs': definitions})
     else:
       # so we don't have a policy directory, we should check if this new
       # directory has a policy directory
-      if curdir in FLAGS.ignore_directories:
+      if curdir in ignore_directories:
         continue
       logging.warning('-' * (2 * depth) + '> %s' % (
           input_dirname + '/' + curdir))
-      files_found = DescendRecursively(input_dirname + '/' + curdir,
-                                       output_dirname + '/' + curdir,
-                                       definitions, depth + 1)
+      files_found = DescendRecursively(
+        input_dirname + '/' + curdir,
+        output_dirname + '/' + curdir,
+        definitions,
+        ignore_directories,
+        depth + 1
+      )
       logging.warning('-' * (2 * depth) + '> %s (%d pol files found)' % (
           input_dirname + '/' + curdir, len(files_found)))
       files.extend(files_found)
@@ -494,8 +494,16 @@ def DiscoverAllPolicies(base_directory, output_directory, definitions):
   return pols
 
 
-def Run(base_directory, definitions_directory, policy_file, output_directory,
-        context):
+def Run(
+  base_directory,
+  definitions_directory,
+  policy_file,
+  output_directory,
+  exp_info,
+  max_renderers,
+  ignore_directories,
+  context
+):
   definitions = None
   try:
     definitions = naming.Naming(definitions_directory)
@@ -511,46 +519,41 @@ def Run(base_directory, definitions_directory, policy_file, output_directory,
   if policy_file:
     # render just one file
     logging.info('rendering one file')
-    RenderFile(base_directory, policy_file, output_directory, definitions,
-               FLAGS.exp_info, write_files)
-  elif FLAGS.max_renderers == 1:
-    # If only one process, run it sequentially
-    policies = DiscoverAllPolicies(
-        base_directory,
-        output_directory,
-        definitions
-    )
-    for pol in policies:
-      RenderFile(
-          base_directory,
-          pol.get('in_file'),
-          pol.get('out_dir'),
-          definitions,
-          FLAGS.exp_info,
-          write_files
-      )
+    RenderFile(
+      base_directory,
+      policy_file,
+      output_directory,
+      definitions,
+      exp_info,
+      write_files)
   else:
     # render all files in parallel
-    policies = DiscoverAllPolicies(
+    logging.info('finding policies...')
+    pols = []
+    pols.extend(
+      DescendRecursively(
         base_directory,
         output_directory,
-        definitions
+        definitions,
+        ignore_directories
+      )
     )
-    pool = context.Pool(processes=FLAGS.max_renderers)
+
+    pool = context.Pool(processes=max_renderers)
     results = []
-    for pol in policies:
+    for x in pols:
       results.append(
-          pool.apply_async(
-              RenderFile,
-              args=(
-                  base_directory,
-                  pol.get('in_file'),
-                  pol.get('out_dir'),
-                  definitions,
-                  FLAGS.exp_info,
-                  write_files
-              )
+        pool.apply_async(
+          RenderFile,
+          args=(
+            base_directory,
+            x.get('in_file'),
+            x.get('out_dir'),
+            definitions,
+            exp_info,
+            write_files
           )
+        )
       )
     pool.close()
     pool.join()
@@ -576,21 +579,34 @@ def Run(base_directory, definitions_directory, policy_file, output_directory,
 def main(argv):
   del argv  # Unused.
 
-  if FLAGS.verbose:
+  configs = config.generate_configs(FLAGS)
+
+  if configs['verbose']:
     logging.set_verbosity(logging.INFO)
-  if FLAGS.debug:
+  if configs['debug']:
     logging.set_verbosity(logging.DEBUG)
-  logging.debug('binary: %s\noptimize: %d\nbase_directory: %s\n'
-                'policy_file: %s\nrendered_acl_directory: %s',
-                str(sys.argv[0]),
-                int(FLAGS.optimize),
-                str(FLAGS.base_directory),
-                str(FLAGS.policy_file),
-                str(FLAGS.output_directory))
+  logging.debug(
+    'binary: %s\noptimize: %d\nbase_directory: %s\n'
+    'policy_file: %s\nrendered_acl_directory: %s',
+    str(sys.argv[0]),
+    int(configs['optimize']),
+    str(configs['base_directory']),
+    str(configs['policy_file']),
+    str(configs['output_directory'])
+  )
+  logging.debug('capirca configurations: %s' % configs)
 
   context = multiprocessing.get_context()
-  Run(FLAGS.base_directory, FLAGS.definitions_directory, FLAGS.policy_file,
-      FLAGS.output_directory, context)
+  Run(
+    configs['base_directory'],
+    configs['definitions_directory'],
+    configs['policy_file'],
+    configs['output_directory'],
+    configs['exp_info'],
+    configs['max_renderers'],
+    configs['ignore_directories'],
+    context
+  )
 
 
 def entry_point():

--- a/capirca/utils/config.py
+++ b/capirca/utils/config.py
@@ -1,0 +1,79 @@
+""" A module to handle merging file configurations with CLI configs for Capirca """
+
+from yaml import load
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
+
+defaults = {
+    'base_directory': './policies',
+    'definitions_directory': './def',
+    'policy_file': None,
+    'output_directory': './',
+    'optimize': False,
+    'recursive': True,
+    'debug': False,
+    'verbose': False,
+    'ignore_directories': ['DEPRECATED', 'def'],
+    'max_renderers': 10,
+    'shade_check': False,
+    'exp_info': 2
+}
+
+
+def yaml_loader(filename):
+    with open(filename, 'r') as f:
+        data = load(f, Loader=Loader)
+
+    return data
+
+
+def flags_to_dict(absl_flags):
+    base = {
+        'base_directory': absl_flags.base_directory,
+        'definitions_directory': absl_flags.definitions_directory,
+        'policy_file': absl_flags.policy_file,
+        'output_directory': absl_flags.output_directory,
+        'optimize': absl_flags.optimize,
+        'recursive': absl_flags.recursive,
+        'debug': absl_flags.debug,
+        'verbose': absl_flags.verbose,
+        'ignore_directories': absl_flags.ignore_directories,
+        'max_renderers': absl_flags.max_renderers,
+        'shade_check': absl_flags.shade_check,
+        'exp_info': absl_flags.exp_info,
+    }
+
+    return {
+        flag: base[flag]
+        for flag in filter(lambda f: base[f] is not None, base)
+    }
+
+
+def merge_files(*files):
+    result = {}
+
+    for item in files:
+        data = yaml_loader(item)
+        result.update(data)
+
+    return {
+        flag: result[flag]
+        for flag in filter(lambda f: result[f] is not None, result)
+    }
+
+
+def generate_configs(absl_flags):
+    cli_configs = flags_to_dict(absl_flags)
+    if absl_flags.config_file:
+        file_configs = merge_files(*absl_flags.config_file)
+    else:
+        file_configs = {}
+
+    result = defaults.copy()
+    result.update(cli_configs)
+    result.update(file_configs)
+
+    return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@
 # Usage:
 #   $ pip install -r requirements.txt
 
-ipaddress>=1.0.22
 absl-py
+ipaddress>=1.0.22
 ply
+PyYAML
 six>=1.12.0

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,12 @@ setup(
         'Topic :: Security',
         'Topic :: System :: Networking :: Firewalls',
     ],
-    install_requires=['absl-py', 'ply', 'ipaddress>=1.0.22', 'six']
+    install_requires=[
+        'absl-py',
+        'ply',
+        'ipaddress>=1.0.22',
+        'mock',
+        'six',
+        'PyYAML',
+    ]
 )

--- a/tests/integration/aclgen_test.py
+++ b/tests/integration/aclgen_test.py
@@ -49,11 +49,22 @@ class TestAclGenDemo(unittest.TestCase):
     shutil.copytree('def', self.def_dir)
     shutil.copytree('policies', self.pol_dir)
     self.context = multiprocessing.get_context()
+    self.max_renderers = 10
+    self.exp_info = 2
+    self.ignore_directories = ['DEPRECATED', 'def']
 
   @mock.patch.object(aclgen, '_WriteFile', autospec=True)
   def test_smoke_test_generates_successfully(self, mock_writer):
-    aclgen.Run(self.pol_dir, self.def_dir, None, self.test_subdirectory,
-               self.context)
+    aclgen.Run(
+      self.pol_dir,
+      self.def_dir,
+      None,
+      self.test_subdirectory,
+      self.exp_info,
+      self.max_renderers,
+      self.ignore_directories,
+      self.context
+    )
     files = ['sample_cisco_lab.acl', 'sample_cloudarmor.gca', 'sample_gce.gce',
              'sample_ipset.ips', 'sample_juniper_loopback.jcl',
              'sample_multitarget.acl', 'sample_multitarget.asa',
@@ -70,8 +81,16 @@ class TestAclGenDemo(unittest.TestCase):
   def test_generate_single_policy(self, mock_writer):
     policy_file = os.path.join(self.test_subdirectory,
                                'policies/pol/sample_cisco_lab.pol')
-    aclgen.Run(self.pol_dir, self.def_dir, policy_file,
-               self.test_subdirectory, self.context)
+    aclgen.Run(
+      self.pol_dir,
+      self.def_dir,
+      policy_file,
+      self.test_subdirectory,
+      self.exp_info,
+      self.max_renderers,
+      self.ignore_directories,
+      self.context
+    )
     mock_writer.assert_called_with(
         os.path.join(self.test_subdirectory, 'sample_cisco_lab.acl'), mock.ANY)
 


### PR DESCRIPTION
Allow the usage of YAML files to configure `aclgen` for Capirca.

Despite the default being stripped from the CLI definition and inserted into the description, there should be no difference between the previous `aclgen --helpfull` to the one that implements this pull request. This is because all config defaults have now been moved to `capirca.utils.config`. Changes to the defaults in that module will translate to changes in the default flags.