### PR TITLE
Update cisco.py to handle using raw protocol numbers in policy #170

### DIFF
--- a/capirca/lib/cisco.py
+++ b/capirca/lib/cisco.py
@@ -522,7 +522,7 @@ class Term(aclgenerator.Term):
     elif self.term.protocol == ['hopopt']:
       protocol = ['hbh']
     elif self.proto_int:
-      protocol = [proto if proto in self.ALLOWED_PROTO_STRINGS
+      protocol = [proto if proto in self.ALLOWED_PROTO_STRINGS or proto.isnumeric()
                   else self.PROTO_MAP.get(proto)
                   for proto in self.term.protocol]
     else:
@@ -835,7 +835,7 @@ class ObjectGroupTerm(Term):
       protocol = ['ip']
 
     else:
-      protocol = [proto if proto in self.ALLOWED_PROTO_STRINGS
+      protocol = [proto if proto in self.ALLOWED_PROTO_STRINGS or proto.isnumeric()
                   else self.PROTO_MAP.get(proto)
                   for proto in self.term.protocol]
 

--- a/tests/lib/cisco_test.py
+++ b/tests/lib/cisco_test.py
@@ -338,6 +338,12 @@ term good_term_22 {
   action:: accept
 }
 """
+GOOD_TERM_23 = """
+term good_term_23 {
+  protocol:: 50
+  action:: accept
+}
+"""
 LONG_COMMENT_TERM = """
 term long-comment-term {
   comment:: "%s "
@@ -878,7 +884,6 @@ class CiscoTest(unittest.TestCase):
         LONG_VERSION_HEADER + GOOD_TERM_7,
         self.naming)
     acl = cisco.Cisco(pol, EXP_INFO)
-    print(acl)
     self.assertIn('remark This long header should be split even on a', str(acl))
     self.assertIn(('remark looooooooooooooooooooooooooonnnnnnnnnnnnnnnnnn'
                    'gggggggggg string.'), str(acl))
@@ -889,6 +894,13 @@ class CiscoTest(unittest.TestCase):
     self.assertIn(('remark 5:0x169ef02a512c5b28!8m2!3d37.4220579!4d-122.084'
                    '0897'), str(acl))
 
+  def testProtocolByNumber(self):
+      """Test policy term refering to protocol by number"""
+      pol = policy.ParsePolicy(
+          GOOD_HEADER + GOOD_TERM_23, self.naming
+      )
+      acl = cisco.Cisco(pol, EXP_INFO)
+      self.assertIn('permit 50 any any', str(acl))
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
- Allowed passing along of raw numeric protocol in Cisco generator, using str.isnumeric() 
- Added test to ensure that this feature works 
- Minor cleanup of errant print statement leftover in other test [cisco_test.py:881]