### PR TITLE
Make FLAGS (optimize, shade_check) available to Run() in MP

### DIFF
--- a/capirca/aclgen.py
+++ b/capirca/aclgen.py
@@ -161,7 +161,7 @@ def SkipLines(text, skip_line_func=False):
 
 
 def RenderFile(base_directory, input_file, output_directory, definitions,
-               exp_info, write_files):
+               exp_info, optimize, shade_check, write_files):
   """Render a single file.
 
   Args:
@@ -171,6 +171,8 @@ def RenderFile(base_directory, input_file, output_directory, definitions,
     definitions: the definitions from naming.Naming().
     exp_info: print a info message when a term is set to expire
               in that many weeks.
+    optimize: a boolean indicating if we should turn on optimization or not.
+    shade_check: should we raise an error if a term is completely shaded
     write_files: a list of file tuples, (output_file, acl_text), to write
   """
   logging.debug('rendering file: %s into %s', input_file,
@@ -210,8 +212,8 @@ def RenderFile(base_directory, input_file, output_directory, definitions,
 
   try:
     pol = policy.ParsePolicy(
-        conf, definitions, optimize=FLAGS.optimize,
-        base_dir=base_directory, shade_check=FLAGS.shade_check)
+        conf, definitions, optimize=optimize,
+        base_dir=base_directory, shade_check=shade_check)
   except policy.ShadingError as e:
     logging.warning('shading errors for %s:\n%s', input_file, e)
     return
@@ -529,6 +531,8 @@ def Run(
     exp_info,
     max_renderers,
     ignore_directories,
+    optimize,
+    shade_check,
     context
 ):
   definitions = None
@@ -552,6 +556,8 @@ def Run(
         output_directory,
         definitions,
         exp_info,
+        optimize,
+        shade_check,
         write_files)
   else:
     # render all files in parallel
@@ -578,6 +584,8 @@ def Run(
                   pol.get('out_dir'),
                   definitions,
                   exp_info,
+                  optimize,
+                  shade_check,
                   write_files
               )
           )
@@ -624,6 +632,7 @@ def main(argv):
   logging.debug('capirca configurations: %s', configs)
 
   context = multiprocessing.get_context()
+
   Run(
       configs['base_directory'],
       configs['definitions_directory'],
@@ -632,6 +641,8 @@ def main(argv):
       configs['exp_info'],
       configs['max_renderers'],
       configs['ignore_directories'],
+      configs['optimize'],
+      configs['shade_check'],
       context
   )
 


### PR DESCRIPTION
Due to the way that multiprocessing now starts processes, FLAGS is not reachable in RenderFile().

This causes (on OS X under Python 3.9 at least) :
```
multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/Users/wkumari/src/github/wkumari-caprica/capirca/aclgen.py", line 213, in RenderFile
    conf, definitions, optimize=FLAGS.optimize,
  File "/usr/local/lib/python3.9/site-packages/absl/flags/_flagvalues.py", line 480, in __getattr__
    raise AttributeError(name)
AttributeError: optimize
"""
```

This seems to be a result of the addition of, and change to using `spawn` as default start method - this can be solved by passing `'fork'` to `context = multiprocessing.get_context()`, but that seems kludgy, so I'm instead passing in the optimize and shade_check flags directly...