### PR TITLE
PA: Add support for source port handling

### DIFF
--- a/capirca/lib/aclcheck.py
+++ b/capirca/lib/aclcheck.py
@@ -184,7 +184,7 @@ class AclCheck(object):
     for match in self.matches:
       if match.action:
         if not match.possibles:
-          if action is 'any' or action in match.action:
+          if action == 'any' or action in match.action:
             match_list.append(match)
     return match_list
 
@@ -249,7 +249,7 @@ class AclCheck(object):
     Returns:
       bool: True of false
     """
-    if addr is 'any': return True   # always true if we match for any addr
+    if addr == 'any': return True   # always true if we match for any addr
     if not addresses: return True   # always true if term has nothing to match
     for ip in addresses:
       # ipaddr can incorrectly report ipv4 as contained with ipv6 addrs


### PR DESCRIPTION
This PR is a proposal to add support for term source port handling to Palo Alto platform, and any suggestions or comments to improve it would be very welcome.

Currently only destination port is supported, and the services that are created to PA are named after the first term that uses them in the Capirca policy files. This change allows using also source ports, and the resulting service is named by combining the source and destination service names from the services definition file plus protocol, instead of using the term name. The source port must also be defined in the services definition file. If the resulting service name is too long, the code falls back to forming a service name using port numbers, which should always fall within acceptable length.

This change would cause a change in all configurations after updating Capirca, since it changes the service names from the term name to using the actual service names from the definitions file.

Example resulting PA service names:
`SOME_SERVICE_TO_WEB_SERVICES_TCP`
`SVC_ANY_TO_80_443_TCP`
