### PR TITLE
PAN-OS: Enhancement to handle term source-port keyword.

### DIFF
--- a/tests/lib/paloaltofw_test.py
+++ b/tests/lib/paloaltofw_test.py
@@ -885,7 +885,11 @@ term rule-1 {
   destination-port:: NTP
 """
 
-    pol = policy.ParsePolicy(POL % T)
+    definitions = naming.Naming()
+    definitions._ParseLine('NTP = 123/tcp 123/udp', 'services')
+    definitions._ParseLine('DNS = 53/tcp 53/udp', 'services')
+
+    pol = policy.ParsePolicy(POL % T, definitions)
     paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
     output = str(paloalto)
     name = "service-rule-1-udp"
@@ -901,7 +905,7 @@ term rule-1 {
   source-port:: NTP
 """
 
-    pol = policy.ParsePolicy(POL % T)
+    pol = policy.ParsePolicy(POL % T, definitions)
     paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
     output = str(paloalto)
     name = "service-rule-1-udp"
@@ -918,7 +922,7 @@ term rule-1 {
   destination-port:: NTP DNS
 """
 
-    pol = policy.ParsePolicy(POL % T)
+    pol = policy.ParsePolicy(POL % T, definitions)
     paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
     output = str(paloalto)
     name = "service-rule-1-tcp"


### PR DESCRIPTION
If source-port is specified add it to a service object.  If there is
no destination-port then add range 0-65535 to the service destination
port because it is required field.  The port range is used vs. "any"
due to recent changes which disallow any in the WebUI.