### PR TITLE
Implement address_family token for Juniper and Cisco

### DIFF
--- a/capirca/lib/aclgenerator.py
+++ b/capirca/lib/aclgenerator.py
@@ -216,6 +216,7 @@ class ACLGenerator:
   # Only warn if these tokens are not implemented by a platform. These are not
   # meant to be overridden in subclasses like supported tokens/sub tokens.
   WARN_IF_UNSUPPORTED = {
+      'restrict_address_family',
       'counter',
       'destination_tag',
       'logging',

--- a/capirca/lib/cisco.py
+++ b/capirca/lib/cisco.py
@@ -905,6 +905,7 @@ class Cisco(aclgenerator.ACLGenerator):
     supported_tokens, supported_sub_tokens = super()._BuildTokens()
 
     supported_tokens |= {'address',
+                         'restrict_address_family',
                          'dscp_match',
                          'icmp_code',
                          'logging',
@@ -987,6 +988,10 @@ class Cisco(aclgenerator.ACLGenerator):
             af = 'inet6'
           term = self.FixHighPorts(term, af=af)
           if not term:
+            continue
+
+          # Ignore if the term is for a different AF
+          if term.restrict_address_family and term.restrict_address_family != af:
             continue
 
           if term.expiration:

--- a/capirca/lib/juniper.py
+++ b/capirca/lib/juniper.py
@@ -871,6 +871,7 @@ class Juniper(aclgenerator.ACLGenerator):
     supported_tokens, supported_sub_tokens = super()._BuildTokens()
 
     supported_tokens |= {'address',
+                         'restrict_address_family',
                          'counter',
                          'destination_prefix',
                          'destination_prefix_except',
@@ -961,6 +962,10 @@ class Juniper(aclgenerator.ACLGenerator):
         term_names = set()
         new_terms = []
         for term in terms:
+
+          # Ignore if the term is for a different AF
+          if term.restrict_address_family and term.restrict_address_family != filter_type:
+            continue
 
           # if inactive is set, deactivate the term and remove the option.
           if 'inactive' in term.option:

--- a/capirca/lib/policy.py
+++ b/capirca/lib/policy.py
@@ -306,6 +306,7 @@ class Term:
       VarType.(S|D)?ADDRESS's
     address_exclude/source_address_exclude/destination_address_exclude: list of
       VarType.(S|D)?ADDEXCLUDE's
+    restrict-address-family: VarType.RESTRICT_ADDRESS_FAMILY
     port/source_port/destination_port: list of VarType.(S|D)?PORT's
     options: list of VarType.OPTION's.
     protocol: list of VarType.PROTOCOL's.
@@ -402,6 +403,7 @@ class Term:
     self.action = []
     self.address = []
     self.address_exclude = []
+    self.restrict_address_family = None
     self.comment = []
     self.counter = None
     self.expiration = None
@@ -1114,7 +1116,9 @@ class Term:
                   type(x), x.value))
     else:
       # stupid no switch statement in python
-      if obj.var_type is VarType.COMMENT:
+      if obj.var_type is VarType.RESTRICT_ADDRESS_FAMILY:
+        self.restrict_address_family = obj.value
+      elif obj.var_type is VarType.COMMENT:
         self.comment.append(str(obj))
       elif obj.var_type is VarType.OWNER:
         self.owner = obj.value
@@ -1493,6 +1497,7 @@ class VarType:
   TARGET_RESOURCES = 59
   TARGET_SERVICE_ACCOUNTS = 60
   ENCAPSULATE = 61
+  RESTRICT_ADDRESS_FAMILY = 63
 
   def __init__(self, var_type, value):
     self.var_type = var_type
@@ -1650,6 +1655,7 @@ tokens = (
     'ACTION',
     'ADDR',
     'ADDREXCLUDE',
+    'RESTRICT_ADDRESS_FAMILY',
     'COMMENT',
     'COUNTER',
     'DADDR',
@@ -1735,6 +1741,7 @@ reserved = {
     'action': 'ACTION',
     'address': 'ADDR',
     'address-exclude': 'ADDREXCLUDE',
+    'restrict-address-family': 'RESTRICT_ADDRESS_FAMILY',
     'comment': 'COMMENT',
     'counter': 'COUNTER',
     'destination-address': 'DADDR',
@@ -1921,6 +1928,7 @@ def p_terms(p):
 def p_term_spec(p):
   """ term_spec : term_spec action_spec
                 | term_spec addr_spec
+                | term_spec restrict_address_family_spec
                 | term_spec comment_spec
                 | term_spec counter_spec
                 | term_spec traffic_class_count_spec
@@ -1973,6 +1981,9 @@ def p_term_spec(p):
     else:
       p[0] = Term(p[2])
 
+def p_restrict_address_family_spec(p):
+  """ restrict_address_family_spec : RESTRICT_ADDRESS_FAMILY ':' ':' STRING """
+  p[0] = VarType(VarType.RESTRICT_ADDRESS_FAMILY, p[4])
 
 def p_routinginstance_spec(p):
   """ routinginstance_spec : ROUTING_INSTANCE ':' ':' STRING """

--- a/doc/generators/cisco.md
+++ b/doc/generators/cisco.md
@@ -17,6 +17,7 @@ The default format is _inet4_, and is implied if not other argument is given.
 ## Term Format
 * _action::_ The action to take when matched. See Actions section for valid options.
 * _address::_ One or more network address tokens, matches source or destination.
+* _restrict-address-family::_ Only include the term in the matching address family filter (eg. for mixed filters).
 * _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
 * _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address

--- a/doc/generators/juniper.md
+++ b/doc/generators/juniper.md
@@ -33,6 +33,7 @@ The default format is _inet4_, and is implied if not other argument is given.
 ## Term Format
 * _action::_ The action to take when matched. See Actions section for valid options.
 * _address::_ One or more network address tokens, matches source or destination.
+* _restrict-address-family::_ Only include the term in the matching address family filter (eg. for mixed filters).
 * _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
 * _counter::_ Update a counter for matching packets
 * _destination-address::_ One or more destination address tokens
@@ -91,4 +92,3 @@ The default format is _inet4_, and is implied if not other argument is given.
 * _sample::_ Samples traffic for netflow.
 * _tcp-established::_ Only match established tcp connections, based on statefull match or TCP flags. Not supported for other protocols.
 * _tcp-initial::_ Only match initial packet for TCP protocol.
-

--- a/policies/pol/sample_juniper_loopback.pol
+++ b/policies/pol/sample_juniper_loopback.pol
@@ -196,6 +196,14 @@ term reject-imap-requests {
   action:: reject-with-tcp-rst
 }
 
+term af-mismatch {
+  comment:: "Will not be generated as target is inet"
+  comment:: "but address_family is inet6"
+  destination-address:: INTERNAL
+  restrict-address-family:: inet6
+  action:: reject
+}
+
 term discard-default {
   counter:: discard-default
   action:: deny

--- a/tests/lib/arista_test.py
+++ b/tests/lib/arista_test.py
@@ -138,6 +138,7 @@ SUPPORTED_TOKENS = {
     'platform',
     'platform_exclude',
     'protocol',
+    'restrict_address_family',
     'source_address',
     'source_address_exclude',
     'source_port',

--- a/tests/lib/brocade_test.py
+++ b/tests/lib/brocade_test.py
@@ -62,6 +62,7 @@ SUPPORTED_TOKENS = {
     'platform',
     'platform_exclude',
     'protocol',
+    'restrict_address_family',
     'source_address',
     'source_address_exclude',
     'source_port',

--- a/tests/lib/cisco_test.py
+++ b/tests/lib/cisco_test.py
@@ -332,6 +332,14 @@ term good_term_22 {
   action:: accept
 }
 """
+GOOD_TERM_23 = """
+term good_term_23 {
+  protocol:: tcp
+  destination-address:: SOME_HOST
+  restrict-address-family:: inet
+  action:: accept
+}
+"""
 LONG_COMMENT_TERM = """
 term long-comment-term {
   comment:: "%s "
@@ -358,6 +366,7 @@ SUPPORTED_TOKENS = {
     'platform',
     'platform_exclude',
     'protocol',
+    'restrict_address_family',
     'source_address',
     'source_address_exclude',
     'source_port',
@@ -684,6 +693,17 @@ class CiscoTest(absltest.TestCase):
     self.assertIn(inet6_test5, aclout, '[%s]' % aclout)
     self.assertTrue(re.search(inet6_test6, aclout), aclout)
 
+    self.naming.GetNetAddr.assert_called_once_with('SOME_HOST')
+
+  def testRestrictAddressFamilyType(self):
+    self.naming.GetNetAddr.return_value = [
+        nacaddr.IPv4('127.0.0.1'), nacaddr.IPv6('::1/128')]
+
+    acl = cisco.Cisco(policy.ParsePolicy(GOOD_MIXED_HEADER + GOOD_TERM_23,
+                                         self.naming), EXP_INFO)
+    output = str(acl)
+    self.assertIn('127.0.0.1', output, output)
+    self.assertNotIn('::1/128', output, output)
     self.naming.GetNetAddr.assert_called_once_with('SOME_HOST')
 
   def testDsmo(self):

--- a/tests/lib/cisconx_test.py
+++ b/tests/lib/cisconx_test.py
@@ -145,6 +145,7 @@ SUPPORTED_TOKENS = {
     'platform',
     'platform_exclude',
     'protocol',
+    'restrict_address_family',
     'source_address',
     'source_address_exclude',
     'source_port',

--- a/tests/lib/ciscoxr_test.py
+++ b/tests/lib/ciscoxr_test.py
@@ -120,6 +120,7 @@ SUPPORTED_TOKENS = {
     'platform',
     'platform_exclude',
     'protocol',
+    'restrict_address_family',
     'source_address',
     'source_address_exclude',
     'source_port',

--- a/tests/lib/srxlo_test.py
+++ b/tests/lib/srxlo_test.py
@@ -98,6 +98,7 @@ SUPPORTED_TOKENS = {
     'protocol',
     'protocol_except',
     'qos',
+    'restrict_address_family',
     'routing_instance',
     'source_address',
     'source_address_exclude',


### PR DESCRIPTION
See issue #245.
To be merged after https://github.com/google/capirca/pull/266
Especially when using mixed target, it is useful to be able to skip a given term for an AF.

Final result, on Juniper:
```
header {
  comment:: "Sample Juniper lookback filter"
  target:: juniper loopback mixed

}
term one {
  source-address:: BOGON
  address-family:: inet
  protocol:: tcp
  action:: accept
}
term two {
  source-address:: BOGON
  address-family:: inet6
  protocol:: udp
  action:: accept
}
term three {
  source-address:: BOGON
  protocol:: gre
  action:: accept
}
```
Outputs:
```
firewall {
    family inet {
        /*
         ** $Id:$
         ** $Date:$
         ** $Revision:$
         **
         ** Sample Juniper lookback filter
         */
        replace: filter loopback4 {
            interface-specific;
            term one {
                from {
                    source-address {
                        0.0.0.0/8;
                        192.0.0.0/24;
                        192.0.2.0/24;
                        198.18.0.0/15;
                        198.51.100.0/24;
                        203.0.113.0/24;
                        /* IP multicast */
                        224.0.0.0/4;
                        240.0.0.0/4;
                    }
                    protocol tcp;
                }
                then accept;
            }
            term three {
                from {
                    source-address {
                        0.0.0.0/8;
                        192.0.0.0/24;
                        192.0.2.0/24;
                        198.18.0.0/15;
                        198.51.100.0/24;
                        203.0.113.0/24;
                        /* IP multicast */
                        224.0.0.0/4;
                        240.0.0.0/4;
                    }
                    protocol gre;
                }
                then accept;
            }
        }
    }
}
firewall {
    family inet6 {
        /*
         ** $Id:$
         ** $Date:$
         ** $Revision:$
         **
         ** Sample Juniper lookback filter
         */
        replace: filter loopback6 {
            interface-specific;
            term two {
                from {
                    source-address {
                        /* IPv6 documentation prefix */
                        2001:db8::/32;
                        /* 6bone */
                        3ffe::/16;
                        /* 6bone */
                        5f00::/8;
                        /* IPv6 multicast */
                        ff00::/8;
                    }
                    next-header udp;
                }
                then accept;
            }
            term three {
                from {
                    source-address {
                        /* IPv6 documentation prefix */
                        2001:db8::/32;
                        /* 6bone */
                        3ffe::/16;
                        /* 6bone */
                        5f00::/8;
                        /* IPv6 multicast */
                        ff00::/8;
                    }
                    next-header gre;
                }
                then accept;
            }
        }
    }
}
```

Similarly on Cisco:
```
header {
  comment:: "mixed inet/inet6 header test"
  target:: cisco mixed_acl mixed
}
term one {
  source-address:: BOGON
  address-family:: inet
  protocol:: tcp
  action:: accept
}
term two {
  source-address:: BOGON
  address-family:: inet6
  protocol:: udp
  action:: accept
}
term three {
  source-address:: BOGON
  protocol:: gre
  action:: accept
}
```
Outputs:
```
! $Id:$
! $Date:$
! $Revision:$
no ip access-list extended mixed_acl
ip access-list extended mixed_acl
 remark $Id:$
 remark mixed inet/inet6 header test


 remark one
 permit tcp 0.0.0.0 0.255.255.255 any
 permit tcp 192.0.0.0 0.0.0.255 any
 permit tcp 192.0.2.0 0.0.0.255 any
 permit tcp 198.18.0.0 0.1.255.255 any
 permit tcp 198.51.100.0 0.0.0.255 any
 permit tcp 203.0.113.0 0.0.0.255 any
 permit tcp 224.0.0.0 15.255.255.255 any
 permit tcp 240.0.0.0 15.255.255.255 any


 remark three
 permit gre 0.0.0.0 0.255.255.255 any
 permit gre 192.0.0.0 0.0.0.255 any
 permit gre 192.0.2.0 0.0.0.255 any
 permit gre 198.18.0.0 0.1.255.255 any
 permit gre 198.51.100.0 0.0.0.255 any
 permit gre 203.0.113.0 0.0.0.255 any
 permit gre 224.0.0.0 15.255.255.255 any
 permit gre 240.0.0.0 15.255.255.255 any

exit

no ipv6 access-list ipv6-mixed_acl
ipv6 access-list ipv6-mixed_acl
 remark $Id:$
 remark mixed inet/inet6 header test


 remark two
 permit udp 2001:db8::/32 any
 permit udp 3ffe::/16 any
 permit udp 5f00::/8 any
 permit udp ff00::/8 any


 remark three
 permit gre 2001:db8::/32 any
 permit gre 3ffe::/16 any
 permit gre 5f00::/8 any
 permit gre ff00::/8 any

exit
```