### PR TITLE
Change entry_point to match EntryPoint from 31235e9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=['tests*']),
     zip_safe=False,
     entry_points={
-        'console_scripts': ['aclgen = capirca.aclgen:entry_point'],
+        'console_scripts': ['aclgen = capirca.aclgen:EntryPoint'],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
31235e9 changed `entry_point` to `EntryPoint`: https://github.com/google/capirca/commit/31235e964c9893f3f3432d84604fbaa727384047#diff-fac8920b3ce980ed873a7f81b9d86a7252e94eb7b5d211c1d3f02da794581b60L667-R654

This updates `setup.py` to change from `entry_point` to `EntryPoint` as well.