### PR TITLE
Add check for ICMP types used with non-ICMP protocols.

### DIFF
--- a/capirca/lib/paloaltofw.py
+++ b/capirca/lib/paloaltofw.py
@@ -624,11 +624,15 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
           raise PaloAltoFWUnsupportedProtocolError(
               "protocol %s is not supported" % proto_name)
 
-        if (term.icmp_type and term.protocol != ['icmp'] and
-            term.protocol != ['icmpv6']):
-          raise UnsupportedFilterError('%s %s' % (
-            'icmp-types specified for non-icmp protocols in term:',
-            term.name))
+        if term.icmp_type:
+          if set(term.protocol) == {'icmp', 'icmpv6'}:
+            raise UnsupportedFilterError('%s %s' % (
+                'icmp-type specified for both icmp and icmpv6 protocols'
+                ' in a single term:', term.name))
+          if term.protocol != ['icmp'] and term.protocol != ['icmpv6']:
+            raise UnsupportedFilterError('%s %s' % (
+                'icmp-type specified for non-icmp protocols in term:',
+                term.name))
 
         new_terms.append(term)
 

--- a/tests/lib/paloaltofw_test.py
+++ b/tests/lib/paloaltofw_test.py
@@ -619,6 +619,15 @@ term rule-1 {
                       paloaltofw.PaloAltoFW, pol, EXP_INFO)
 
     T = """
+  protocol:: icmpv6 icmp
+  icmp-type:: echo-request
+"""
+
+    pol = policy.ParsePolicy(POL % ("mixed", T), self.naming)
+    self.assertRaises(paloaltofw.UnsupportedFilterError,
+                      paloaltofw.PaloAltoFW, pol, EXP_INFO)
+
+    T = """
   protocol:: icmpv6
   icmp-type:: echo echo-reply
 """


### PR DESCRIPTION
Add unit tests for check above, and invalid ICMP type.

Background: this check was previously handled in
aclgenerator.Term.NormalizeIcmpTypes(), and the function call was
removed.  NormalizeIcmpTypes() is not address family "mixed" aware, so
just added the missing check needed.  And the local Term() class is
no longer needed, so remove it.