### PR TITLE
Update windows.yml to fix action

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Build, install, and run
       run: |
         python setup.py sdist bdist_wheel
-        python -m pip -v install --find-links=dist capirca
+        python -m pip -v install --find-links=dist --no-index capirca
         aclgen --output_directory .\output --logtostderr
         powershell Compress-Archive -Force output\* output.zip
     - name: Upload generated policies


### PR DESCRIPTION
The Windows action is using Capirca from the pypi, when it should be installing Capirca from the local filesystem. 

It seems like --no-index not being used causes it to install from pypi, as can be seen in https://github.com/google/capirca/runs/2949891967?check_suite_focus=true#step:7:284