### PR TITLE
Define and document behavior for pan-application usage.

### DIFF
--- a/capirca/lib/paloaltofw.py
+++ b/capirca/lib/paloaltofw.py
@@ -431,6 +431,14 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
                                              term.name)
         term_dup_check.add(term.name)
 
+        services = {"tcp", "udp"} & set(term.protocol)
+        others = set(term.protocol) - services
+        if others and term.pan_application:
+          raise UnsupportedFilterError(
+            "Term %s contains non tcp, udp protocols with pan-application: %s: %s"
+            "\npan-application can only be used with protocols tcp, udp" %
+            (term.name, ', '.join(term.pan_application), ', '.join(term.protocol)))
+
         if term.expiration:
           if term.expiration <= exp_info_date:
             logging.info(

--- a/doc/generators/paloaltofw.md
+++ b/doc/generators/paloaltofw.md
@@ -45,6 +45,23 @@ target:: paloalto from-zone [zone name] to-zone [zone name] [address family] [ad
 
 ## Terms Section
 ### Optionally Supported Keywords
-  * _pan-application_:: paloalto only, specify a Palo Alto application.
-Application can be a predefined application or a custom application object.
-If an application is specified with no port, the service will default to "application-default".
+  * _pan-application_:: paloalto target only.
+    Specify applications for the security policy which can be predefined
+    applications (https://applipedia.paloaltonetworks.com/)
+    and custom application objects.
+
+    - _Security Policy Service Setting_
+
+      When no _protocol_ is specified in the term, the service will be
+      _application-default_.
+
+      When _protocol_ is tcp or udp, and no _source-port_ or
+      _destination-port_ is specified, the service will be custom
+      service objects for the protocols and all ports (0-65535).
+
+      When _protocol_ is tcp or udp, and a _source-port_ or
+      _destination-port_ is specified, the service will be custom
+      service objects for the protocols and ports.
+
+      _pan-application_ can only be used when no _protocol_ is specified
+      in the term, or the protocols tcp and udp.

--- a/policies/pol/sample_paloalto.pol
+++ b/policies/pol/sample_paloalto.pol
@@ -8,14 +8,14 @@ header {
   target:: paloalto from-zone internal to-zone external
 }
 
-term ping-gdns{
+term ping-gdns {
   source-address:: INTERNAL
   destination-address:: GOOGLE_DNS
   protocol:: icmp
   action:: accept
 }
 
-term dns-gdns{
+term dns-gdns {
   source-address:: INTERNAL
   destination-address:: GOOGLE_DNS
   destination-port:: DNS
@@ -23,7 +23,7 @@ term dns-gdns{
   action:: accept
 }
 
-term allow-web-outbound{
+term allow-web-outbound {
   source-address:: INTERNAL
   destination-port:: WEB_SERVICES
   protocol:: tcp
@@ -34,20 +34,28 @@ header {
   target:: paloalto from-zone external to-zone internal
 }
 
-term allow-icmp{
+term allow-icmp {
   protocol:: icmp
   action:: accept
 }
 
-term allow-only-pan-app{
+# pan-application only: service application-default
+term allow-pan-app-01 {
   pan-application:: web-browsing
   action:: accept
 }
 
-term allow-web-inbound{
-  destination-address:: WEB_SERVERS
-  destination-port:: WEB_SERVICES
-  pan-application:: ssl web-browsing
+# pan-application + tcp: service any-tcp
+term allow-pan-app-02 {
+  pan-application:: web-browsing
   protocol:: tcp
+  action:: accept
+}
+
+# pan-application + ports: service custom service objects
+term allow-pan-app-03 {
+  pan-application:: ssl
+  protocol:: tcp
+  destination-port:: HTTPS IMAPS
   action:: accept
 }


### PR DESCRIPTION
pan-application:: paloalto target only. Specify applications for the
security policy which can be predefined applications
(https://applipedia.paloaltonetworks.com/) and custom application
objects.

  Security Policy Service Setting

    When no protocol is specified in the term, the service will be
    application-default.

    When protocol is tcp or udp, and no source-port or
    destination-port is specified, the service will be custom service
    objects for the protocols and all ports (0-65535).

    When protocol is tcp or udp, and a source-port or destination-port
    is specified, the service will be custom service objects for the
    protocols and ports.

    pan-application can only be used when no protocol is specified in
    the term, or the protocols tcp and udp.