### PR TITLE
Issue 295

### DIFF
--- a/capirca/lib/cisco.py
+++ b/capirca/lib/cisco.py
@@ -927,8 +927,8 @@ class Cisco(aclgenerator.ACLGenerator):
     exp_info_date = current_date + datetime.timedelta(weeks=exp_info)
 
     # a mixed filter outputs both ipv4 and ipv6 acls in the same output file
-    good_filters = ['extended', 'standard', 'object-group', 'inet6',
-                    'mixed', 'enable_dsmo']
+    good_filters = ['extended', 'standard', 'object-group', 
+                    'object-group-inet6', 'inet6', 'mixed', 'enable_dsmo']
 
     for header, terms in pol.filters:
       if self._PLATFORM not in header.platforms:
@@ -1019,6 +1019,10 @@ class Cisco(aclgenerator.ACLGenerator):
             obj_target.AddTerm(term)
             new_terms.append(self._GetObjectGroupTerm(term, filter_name,
                                                       verbose=self.verbose))
+          elif next_filter == 'object-group-inet6':
+            obj_target.AddTerm(term)
+            new_terms.append(self._GetObjectGroupTerm(term, filter_name,
+                                                      verbose=self.verbose))
           elif next_filter == 'inet6':
             new_terms.append(
                 Term(
@@ -1061,7 +1065,7 @@ class Cisco(aclgenerator.ACLGenerator):
     elif filter_type == 'object-group':
       target.append('no ip access-list extended %s' % filter_name)
       target.append('ip access-list extended %s' % filter_name)
-    elif filter_type == 'inet6':
+    elif filter_type == 'inet6' or filter_type == 'object-group-inet6':
       target.append('no ipv6 access-list %s' % filter_name)
       target.append('ipv6 access-list %s' % filter_name)
     else:
@@ -1091,7 +1095,7 @@ class Cisco(aclgenerator.ACLGenerator):
         ) in self.cisco_policies:
       for filter_type in filter_list:
         target.extend(self._AppendTargetByFilterType(filter_name, filter_type))
-        if filter_type == 'object-group':
+        if filter_type == 'object-group' or filter_type == 'object-group-inet6':
           obj_target.AddName(filter_name)
 
         # Add the Perforce Id/Date tags, these must come after

--- a/capirca/lib/cisconx.py
+++ b/capirca/lib/cisconx.py
@@ -66,7 +66,7 @@ class CiscoNX(cisco.Cisco):
     elif filter_type == 'object-group':
       target.append('no ip access-list %s' % filter_name)
       target.append('ip access-list %s' % filter_name)
-    elif filter_type == 'inet6':
+    elif filter_type == 'inet6' or filter_type == 'object-group-inet6':
       target.append('no ipv6 access-list %s' % filter_name)
       target.append('ipv6 access-list %s' % filter_name)
     else:

--- a/capirca/lib/ciscoxr.py
+++ b/capirca/lib/ciscoxr.py
@@ -37,7 +37,7 @@ class CiscoXR(cisco.Cisco):
       list of strings
     """
     target = []
-    if filter_type == 'inet6':
+    if filter_type == 'inet6' or filter_type == 'object-group-inet6':
       target.append('no ipv6 access-list %s' % filter_name)
       target.append('ipv6 access-list %s' % filter_name)
     else:

--- a/doc/generators/cisco.md
+++ b/doc/generators/cisco.md
@@ -2,12 +2,13 @@
 
 The cisco header designation has the following format:
 ```
-target:: cisco [filter name] {extended|standard|object-group|inet6|mixed} {dsmo}
+target:: cisco [filter name] {extended|standard|object-group|object-group-inet6|inet6|mixed} {dsmo}
 ```
   * _filter name_: defines the name or number of the cisco filter.
   * _extended_: specifies that the output should be an extended access list, and the filter name should be non-numeric.  This is the default option.
   * _standard_: specifies that the output should be a standard access list, and the filter name should be numeric and in the range of 1-99.
   * _object-group_: specifies this is a cisco extended access list, and that object-groups should be used for ports and addresses.
+  * _object-group-inet6_: specifies this is a cisco extended ipv6 access list, and that object-groups should be used for ports and addresses.
   * _inet6_: specifies the output be for IPv6 only filters.
   * _mixed_: specifies output will include both IPv6 and IPv4 filters.
   * _dsmo_: Enable discontinuous subnet mask summarization.

--- a/tests/lib/cisco_test.py
+++ b/tests/lib/cisco_test.py
@@ -50,10 +50,16 @@ header {
   target:: cisco 50 standard
 }
 """
-GOOD_OBJGRP_HEADER = """
+GOOD_OBJGRP_HEADER_1 = """
 header {
   comment:: "obj group header test"
   target:: cisco objgroupheader object-group
+}
+"""
+GOOD_OBJGRP_HEADER_2 = """
+header {
+  comment:: "obj group header test"
+  target:: cisco objgroupheader object-group-inet6
 }
 """
 GOOD_INET6_HEADER = """
@@ -631,9 +637,49 @@ class CiscoTest(absltest.TestCase):
     self.naming.GetServiceByProto.return_value = ['80']
 
     pol = policy.ParsePolicy(
-        GOOD_OBJGRP_HEADER + GOOD_TERM_2 + GOOD_TERM_18, self.naming)
+        GOOD_OBJGRP_HEADER_1 + GOOD_TERM_2 + GOOD_TERM_18, self.naming)
     acl = cisco.Cisco(pol, EXP_INFO)
+    self.assertIn('\n'.join(ip_grp), str(acl), '%s %s' % (
+        '\n'.join(ip_grp), str(acl)))
+    self.assertIn('\n'.join(port_grp1), str(acl), '%s %s' % (
+        '\n'.join(port_grp1), str(acl)))
+    self.assertIn('\n'.join(port_grp2), str(acl), '%s %s' % (
+        '\n'.join(port_grp2), str(acl)))
 
+    # Object-group terms should use the object groups created.
+    self.assertIn(
+        ' permit tcp any port-group 80-80 net-group SOME_HOST port-group'
+        ' 1024-65535', str(acl), str(acl))
+    self.assertIn(
+        ' permit ip net-group SOME_HOST net-group SOME_HOST', str(acl),
+        str(acl))
+
+    # There should be no addrgroups that look like IP addresses.
+    for addrgroup in re.findall(r'net-group ([a-f0-9.:/]+)', str(acl)):
+      self.assertRaises(ValueError, nacaddr.IP(addrgroup))
+
+    self.naming.GetNetAddr.assert_has_calls([mock.call('SOME_HOST'),
+                                             mock.call('SOME_HOST')])
+    self.naming.GetServiceByProto.assert_called_once_with('HTTP', 'tcp')
+
+  def testObjectGroupInet6(self):
+    ip_grp = ['object-group network ipv6 SOME_HOST']
+    ip_grp.append(' 2001::3/128')
+    ip_grp.append('exit')
+    port_grp1 = ['object-group port 80-80']
+    port_grp1.append(' eq 80')
+    port_grp1.append('exit')
+    port_grp2 = ['object-group port 1024-65535']
+    port_grp2.append(' range 1024 65535')
+    port_grp2.append('exit')
+
+    self.naming.GetNetAddr.return_value = [
+        nacaddr.IP('2001::3/128', token='SOME_HOST')]
+    self.naming.GetServiceByProto.return_value = ['80']
+
+    pol = policy.ParsePolicy(
+        GOOD_OBJGRP_HEADER_2 + GOOD_TERM_2 + GOOD_TERM_18, self.naming)
+    acl = cisco.Cisco(pol, EXP_INFO)
     self.assertIn('\n'.join(ip_grp), str(acl), '%s %s' % (
         '\n'.join(ip_grp), str(acl)))
     self.assertIn('\n'.join(port_grp1), str(acl), '%s %s' % (

--- a/tests/lib/ciscoxr_test.py
+++ b/tests/lib/ciscoxr_test.py
@@ -36,11 +36,18 @@ header {
 }
 """
 
-OBJECT_GROUP_HEADER = """
+OBJECT_GROUP_HEADER_1 = """
 header {
   target:: ciscoxr foo object-group
 }
 """
+
+OBJECT_GROUP_HEADER_2 = """
+header {
+  target:: ciscoxr foo object-group-inet6
+}
+"""
+
 GOOD_TERM_1 = """
 term good-term-1 {
   source-address:: SOME_HOST
@@ -324,9 +331,17 @@ class CiscoXRTest(absltest.TestCase):
 
   def testVerbatimObjectGroup(self):
     self.naming.GetNetAddr.return_value = [nacaddr.IP('10.1.1.1/32')]
-    pol = policy.ParsePolicy(OBJECT_GROUP_HEADER + VERBATIM_TERM, self.naming)
+    pol = policy.ParsePolicy(OBJECT_GROUP_HEADER_1 + VERBATIM_TERM, self.naming)
     acl = ciscoxr.CiscoXR(pol, EXP_INFO)
     self.assertIn('permit tcp any', str(acl))
+
+
+  def testVerbatimObjectGroupIPv6(self):
+    self.naming.GetNetAddr.return_value = [nacaddr.IP('2001::3/128')]
+    pol = policy.ParsePolicy(OBJECT_GROUP_HEADER_2 + VERBATIM_TERM, self.naming)
+    acl = ciscoxr.CiscoXR(pol, EXP_INFO)
+    self.assertIn('permit tcp any', str(acl))
+    self.assertIn('ipv6 access-list foo', str(acl))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #295

This PR adds support for ipv6 object-group access lists in the Cisco generators. 