### PR TITLE
New flag: --[no]apply_groups to enable/disable apply-groups creation for Juniper MS-MPC

### DIFF
--- a/capirca/utils/config.py
+++ b/capirca/utils/config.py
@@ -14,7 +14,8 @@ defaults = {
     'ignore_directories': ['DEPRECATED', 'def'],
     'max_renderers': 10,
     'shade_check': False,
-    'exp_info': 2
+    'exp_info': 2,
+    'apply_groups': True,
 }
 
 
@@ -42,6 +43,7 @@ def flags_to_dict(absl_flags):
       'max_renderers': absl_flags.max_renderers,
       'shade_check': absl_flags.shade_check,
       'exp_info': absl_flags.exp_info,
+      'apply_groups': absl_flags.apply_groups,
   }
 
   return {


### PR DESCRIPTION
Currently capirca generates Juniper MS-MPC as apply-groups. The other way to use those rules is to directly embed them in the services stateful-firewall hierachy.
This PR introduces a switch apply_groups which changes this behaviour. It is set to True by default to not change default behaviour.