### PR TITLE
Add support for 'decapsulate' on Juniper platforms

### DIFF
--- a/capirca/lib/juniper.py
+++ b/capirca/lib/juniper.py
@@ -140,6 +140,7 @@ class Term(aclgenerator.Term):
              'next': 'next term',
              'reject-with-tcp-rst': 'reject tcp-reset',
              'encapsulate': 'encapsulate',
+             'decapsulate': 'decapsulate',
              'port-mirror': 'port-mirror'}
 
   # the following lookup table is used to map between the various types of
@@ -566,6 +567,8 @@ class Term(aclgenerator.Term):
       unique_actions.update(self.term.action)
     if self.term.encapsulate:
       unique_actions.add('encapsulate')
+    if self.term.decapsulate:
+      unique_actions.add('decapsulate')
     if len(unique_actions) <= 1:
       for action in [
           self.term.logging, self.term.routing_instance, self.term.counter,
@@ -609,6 +612,10 @@ class Term(aclgenerator.Term):
       elif current_action == 'encapsulate':
         config.Append('then {')
         config.Append('encapsulate %s;' % str(self.term.encapsulate))
+        config.Append('}')
+      elif current_action == 'decapsulate':
+        config.Append('then {')
+        config.Append('decapsulate %s;' % str(self.term.decapsulate))
         config.Append('}')
       else:
         config.Append('then %s;' % current_action)
@@ -655,6 +662,8 @@ class Term(aclgenerator.Term):
           config.Append('next-ip6 %s;' % str(self.term.next_ip[0]))
       if self.term.encapsulate:
         config.Append('encapsulate %s;' % str(self.term.encapsulate))
+      if self.term.decapsulate:
+        config.Append('decapsulate %s;' % str(self.term.decapsulate))
       for action in self.extra_actions:
         config.Append(action + ';')
 
@@ -689,6 +698,8 @@ class Term(aclgenerator.Term):
     action = set(self.term.action)
     if self.term.encapsulate:
       action.add(self.term.encapsulate)
+    if self.term.decapsulate:
+      action.add(self.term.decapsulate)
     if self.term.routing_instance:
       action.add(self.term.routing_instance)
     if len(action) > 1:
@@ -893,6 +904,7 @@ class Juniper(aclgenerator.ACLGenerator):
     supported_tokens |= {'address',
                          'restrict_address_family',
                          'counter',
+                         'decapsulate',
                          'destination_prefix',
                          'destination_prefix_except',
                          'dscp_except',

--- a/capirca/lib/policy_simple.py
+++ b/capirca/lib/policy_simple.py
@@ -142,6 +142,10 @@ class Encapsulate(Field):
   """An encapsulate field."""
 
 
+class Decapsulate(Field):
+  """An decapsulate field."""
+
+
 class DestinationAddress(Address):
   """A destination-address field."""
 
@@ -383,6 +387,7 @@ field_map = {
     'verbatim': Verbatim,
     'vpn': Vpn,
     'encapsulate': Encapsulate,
+    'decapsulate': Decapsulate,
 }
 
 

--- a/capirca/lib/srxlo.py
+++ b/capirca/lib/srxlo.py
@@ -57,6 +57,8 @@ class SRXlo(juniper.Juniper):
     supported_tokens.remove('flexible_match_range')
     # currently only support 'encapsulate' in juniper
     supported_tokens.remove('encapsulate')
+    # currently only support 'decapsulate' in juniper
+    supported_tokens.remove('decapsulate')
     # currently only support 'port-mirror' in juniper
     supported_tokens.remove('port_mirror')
     return supported_tokens, supported_sub_tokens

--- a/tests/lib/juniper_test.py
+++ b/tests/lib/juniper_test.py
@@ -476,6 +476,40 @@ term bad-term-2 {
   routing-instance:: instance-name
 }
 """
+DECAPSULATE_GOOD_TERM_1 = """
+term good-term-1 {
+  protocol:: udp
+  decapsulate:: template-name
+}
+"""
+DECAPSULATE_GOOD_TERM_2 = """
+term good-term-2 {
+  protocol:: udp
+  decapsulate:: template-name
+  counter:: count-name
+}
+"""
+DECAPSULATE_BAD_TERM_1 = """
+term bad-term-1 {
+  protocol:: udp
+  decapsulate:: template-name
+  action:: accept
+}
+"""
+DECAPSULATE_BAD_TERM_2 = """
+term bad-term-2 {
+  protocol:: udp
+  decapsulate:: template-name
+  routing-instance:: instance-name
+}
+"""
+DECAPSULATE_BAD_TERM_3 = """
+term bad-term-2 {
+  protocol:: udp
+  decapsulate:: template-name
+  encapsulate:: something
+}
+"""
 PORTMIRROR_GOOD_TERM_1 = """
 term good-term-1 {
   protocol:: tcp
@@ -606,6 +640,7 @@ SUPPORTED_TOKENS = frozenset([
     'dscp_except',
     'dscp_match',
     'dscp_set',
+    'decapsulate',
     'encapsulate',
     'ether_type',
     'expiration',
@@ -811,6 +846,33 @@ class JuniperTest(parameterized.TestCase):
     self.assertRaises(juniper.JuniperMultipleTerminatingActionError, str, jcl)
     jcl = juniper.Juniper(
         policy.ParsePolicy(GOOD_HEADER + ENCAPSULATE_BAD_TERM_2, self.naming),
+        EXP_INFO)
+    self.assertRaises(juniper.JuniperMultipleTerminatingActionError, str, jcl)
+
+  def testDecapsulate(self):
+    jcl = juniper.Juniper(
+        policy.ParsePolicy(GOOD_HEADER + DECAPSULATE_GOOD_TERM_1, self.naming),
+        EXP_INFO)
+    output = str(jcl)
+    self.assertIn('decapsulate template-name;', output, output)
+    jcl = juniper.Juniper(
+        policy.ParsePolicy(GOOD_HEADER + DECAPSULATE_GOOD_TERM_2, self.naming),
+        EXP_INFO)
+    output = str(jcl)
+    self.assertIn('decapsulate template-name;', output, output)
+    self.assertIn('count count-name;', output, output)
+
+  def testFailDecapsulate(self):
+    jcl = juniper.Juniper(
+        policy.ParsePolicy(GOOD_HEADER + DECAPSULATE_BAD_TERM_1, self.naming),
+        EXP_INFO)
+    self.assertRaises(juniper.JuniperMultipleTerminatingActionError, str, jcl)
+    jcl = juniper.Juniper(
+        policy.ParsePolicy(GOOD_HEADER + DECAPSULATE_BAD_TERM_2, self.naming),
+        EXP_INFO)
+    self.assertRaises(juniper.JuniperMultipleTerminatingActionError, str, jcl)
+    jcl = juniper.Juniper(
+        policy.ParsePolicy(GOOD_HEADER + DECAPSULATE_BAD_TERM_3, self.naming),
         EXP_INFO)
     self.assertRaises(juniper.JuniperMultipleTerminatingActionError, str, jcl)
 

--- a/tests/lib/policy_test.py
+++ b/tests/lib/policy_test.py
@@ -439,6 +439,12 @@ term good-term-48 {
   action:: accept
 }
 """
+GOOD_TERM_49 = """
+term good-term-46 {
+  protocol:: udp
+  decapsulate:: mpls-in-udp
+}
+"""
 GOOD_TERM_V6_1 = """
 term good-term-v6-1 {
   hop-limit:: 5
@@ -1244,6 +1250,11 @@ class PolicyTest(absltest.TestCase):
     pol = HEADER + GOOD_TERM_46
     result = policy.ParsePolicy(pol, self.naming)
     self.assertIn('encapsulate: stuff_and_things', str(result))
+
+  def testDecapsulate(self):
+    pol = HEADER + GOOD_TERM_49
+    result = policy.ParsePolicy(pol, self.naming)
+    self.assertIn('decapsulate: mpls-in-udp', str(result))
 
   def testPortMirror(self):
     pol = HEADER + GOOD_TERM_47


### PR DESCRIPTION
This adds support for `decapsulate` actions on Juniper, for example `decapsulate mpls-in-udp` which is available on (at least some) MXes and QFXes.

Trying to figure out if CLA is already in place, opening this already to gather feedback :-) 