### PR TITLE
Remove ipaddress unnecessary dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 #   $ pip install -r requirements.txt
 
 absl-py
-ipaddress>=1.0.22
 ply
 PyYAML
 six>=1.12.0

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setuptools.setup(
     install_requires=[
         'absl-py',
         'ply',
-        'ipaddress>=1.0.22',
         'mock',
         'six',
         'PyYAML',


### PR DESCRIPTION
It seems like Capirca targets Python 3.6+. The ipaddress library is
available natively beginning with Python 3.3+, or having it listed under
the project requirements pulls the PyPI library which hasn't seen
a release in almost 3 years and has a number of security issues:

- https://cwe.mitre.org/data/definitions/327.html
- https://www.cve.org/CVERecord?id=CVE-2021-29921
- https://www.cve.org/CVERecord?id=CVE-2020-14422