### PR TITLE
Add Juniper ethernet-switching and specific tcp-flag support 

### DIFF
--- a/capirca/lib/aclgenerator.py
+++ b/capirca/lib/aclgenerator.py
@@ -99,7 +99,8 @@ class Term:
               }
   AF_MAP = {'inet': 4,
             'inet6': 6,
-            'bridge': 4  # if this doesn't exist, output includes v4 & v6
+            'bridge': 4,  # if this doesn't exist, output includes v4 & v6
+            'ethernet-switching': 4
            }
   # These protos are always expressed as numbers instead of name
   #  due to inconsistencies on the end platform's name-to-number

--- a/capirca/lib/juniper.py
+++ b/capirca/lib/juniper.py
@@ -169,7 +169,7 @@ class Term(aclgenerator.Term):
                            'daddr': 'ip-destination-address',
                            'protocol': 'ip-protocol',
                            'protocol-except': 'ip-protocol-except',
-                           'tcp-est': 'tcp-flags "(ack|rst)"'}
+                           'tcp-est': 'tcp-flags "(ack|rst)"'},
                 'ethernet-switching': {'addr': 'ip-address',
                            'saddr': 'ip-source-address',
                            'daddr': 'ip-destination-address',

--- a/capirca/lib/juniper.py
+++ b/capirca/lib/juniper.py
@@ -902,7 +902,7 @@ class Juniper(aclgenerator.ACLGenerator):
 
   _PLATFORM = 'juniper'
   _DEFAULT_PROTOCOL = 'ip'
-  _SUPPORTED_AF = frozenset(('inet', 'inet6', 'bridge', 'mixed'))
+  _SUPPORTED_AF = frozenset(('inet', 'inet6', 'bridge', 'ethernet-switching', 'mixed'))
   _TERM = Term
   SUFFIX = '.jcl'
 


### PR DESCRIPTION
Dear Capirca team,
Following issue #322 I've added support for Juniper ethernet-switching family filters with is basically same syntax as bridge family.
I've also added specific tcp-flags option to protect against stateless filter bypass/exploitation: https://www.youtube.com/watch?v=pjRKUx6bVE0
If needed we could also include flags requested in PR #251 but I guess having a comprehensive way to define tcp-flags combination would be next step? 
Thanks for the review.  