### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,54 +212,54 @@ token_name    | definition
 *   **icmp-type**
     *   specific icmp-type code to match (IPv4/IPv6 types vary).
         *   IPv4:
-        *   echo-reply
-        *   unreachable
-        *   source-quench
-        *   redirect
-        *   alternate-address
-        *   echo-request
-        *   router-advertisement
-        *   router-solicitation
-        *   time-exceeded
-        *   parameter-problem
-        *   timestamp-request
-        *   timestamp-reply
-        *   information-request
-        *   information-reply
-        *   mask-request
-        *   mask-reply
-        *   conversion-error
-        *   mobile-redirect
+            *   echo-reply
+            *   unreachable
+            *   source-quench
+            *   redirect
+            *   alternate-address
+            *   echo-request
+            *   router-advertisement
+            *   router-solicitation
+            *   time-exceeded
+            *   parameter-problem
+            *   timestamp-request
+            *   timestamp-reply
+            *   information-request
+            *   information-reply
+            *   mask-request
+            *   mask-reply
+            *   conversion-error
+            *   mobile-redirect
         *   IPv6:
-        *   destination-unreachable
-        *   packet-too-big
-        *   time-exceeded
-        *   parameter-problem
-        *   echo-request
-        *   echo-reply
-        *   multicast-listener-query
-        *   multicast-listener-report
-        *   multicast-listener-done
-        *   router-solicit
-        *   router-advertisement
-        *   neighbor-solicit
-        *   neighbor-advertisement
-        *   redirect-message
-        *   router-renumbering
-        *   icmp-node-information-query
-        *   icmp-node-information-response
-        *   inverse-neighbor-discovery-solicitation
-        *   inverse-neighbor-discovery-advertisement
-        *   version-2-multicast-listener-report
-        *   home-agent-address-discovery-request
-        *   home-agent-address-discovery-reply
-        *   mobile-prefix-solicitation
-        *   mobile-prefix-advertisement
-        *   certification-path-solicitation
-        *   certification-path-advertisement
-        *   multicast-router-advertisement
-        *   multicast-router-solicitation
-        *   multicast-router-termination
+            *   destination-unreachable
+            *   packet-too-big
+            *   time-exceeded
+            *   parameter-problem
+            *   echo-request
+            *   echo-reply
+            *   multicast-listener-query
+            *   multicast-listener-report
+            *   multicast-listener-done
+            *   router-solicit
+            *   router-advertisement
+            *   neighbor-solicit
+            *   neighbor-advertisement
+            *   redirect-message
+            *   router-renumbering
+            *   icmp-node-information-query
+            *   icmp-node-information-response
+            *   inverse-neighbor-discovery-solicitation
+            *   inverse-neighbor-discovery-advertisement
+            *   version-2-multicast-listener-report
+            *   home-agent-address-discovery-request
+            *   home-agent-address-discovery-reply
+            *   mobile-prefix-solicitation
+            *   mobile-prefix-advertisement
+            *   certification-path-solicitation
+            *   certification-path-advertisement
+            *   multicast-router-advertisement
+            *   multicast-router-solicitation
+            *   multicast-router-termination
 *   **option**
     *   connection options.
         *   **established**
@@ -272,7 +272,7 @@ token_name    | definition
                 adds 1024-65535 to required destination-ports.
         *   **sample**
             *   not supported by all generators. Samples traffic for netflow.
-        *   **intial**
+        *   **initial**
             *   currently only supported by juniper generator. Appends
                 tcp-initial to the term.
         *   **rst**


### PR DESCRIPTION
1. intial -> initial
2. properly indent icmp-type section