### PR TITLE
Move flake8 URL from GitLab to GitHub.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: '3.8.3'
     hooks:
       - id: flake8


### PR DESCRIPTION
This is mentioned in flake8 4.0.0 release notes. Other online sources show that the old Gitlab repository is not functional anymore.

Related: https://github.com/pycqa/flake8/pull/1305