### PR TITLE
nsxt: Typing fixes for Python 3.6 compatibility.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ absl-py
 ply
 PyYAML
 six>=1.12.0
+typing_extensions

--- a/tests/lib/nsxt_test.py
+++ b/tests/lib/nsxt_test.py
@@ -16,7 +16,7 @@
 
 import copy
 import json
-from typing import Any, Literal, Tuple, Union
+from typing import Any, Tuple, Union, Dict, List
 from unittest import mock
 
 from absl.testing import absltest
@@ -25,6 +25,7 @@ from capirca.lib import nacaddr
 from capirca.lib import naming
 from capirca.lib import nsxt
 from capirca.lib import policy
+from typing_extensions import Literal
 
 
 ICMPV6_TERM = """\
@@ -864,14 +865,14 @@ class TestTrafficKindGrid(parameterized.TestCase):
 
   # Which address set should be put into the policy, based on the type of policy
   # we're testing?
-  KIND_TO_ADDRESS: dict[_TRAFFIC_KIND, _ADDRESSES] = {
+  KIND_TO_ADDRESS: Dict[_TRAFFIC_KIND, _ADDRESSES] = {
       'mixed': 'GOOGLE_DNS',
       'v4': 'INTERNAL_V4',
       'v6': 'INTERNAL_V6'}
 
   # Which expanded address group (e.g. netblocks) is expected, based on the type
   # of policy we're testing?
-  KIND_TO_ADDRESS_GROUPS: dict[
+  KIND_TO_ADDRESS_GROUPS: Dict[
       _TRAFFIC_KIND, Union[nacaddr.IPv4, nacaddr.IPv6, Literal['ANY']]] = {
           # 'GOOGLE_DNS'
           'mixed': [nacaddr.IP('8.8.4.4/32'), nacaddr.IP('8.8.8.8/32'),
@@ -961,11 +962,11 @@ class TestTrafficKindGrid(parameterized.TestCase):
         '  destination-address:: INTERNAL_V6',
         '}']))
 
-  def get_source_dest_addresses(self, nsxt_json: dict[str, Any]) -> (
-      Tuple[list[str], list[str]]):
-    rules: list[dict[str, Any]] = nsxt_json['rules']
-    src: list[str] = []
-    dst: list[str] = []
+  def get_source_dest_addresses(self, nsxt_json: Dict[str, Any]) -> (
+      Tuple[List[str], List[str]]):
+    rules: List[Dict[str, Any]] = nsxt_json['rules']
+    src: List[str] = []
+    dst: List[str] = []
 
     for rule in rules:
       src.extend(i for i in rule['source_groups'])


### PR DESCRIPTION
Ability to run checked mainly by running `docker build --tag=capirca .` and `docker run capirca`, since the current `Dockerfile` conveniently uses Python 3.6.

To run the tests, a separate `Dockerfile.tests` was used (but not submitted) with the following changes:

    WORKDIR /app

    ENTRYPOINT ["python3", "-m", "unittest", "discover", "-s", ".", "-p", "nsxt_test.py", "-v"]

and running the test as follows:

    docker build -f Dockerfile.tests --tag capirca:test_nsxt .
    docker run capirca:test_nsxt

Fixes #345.