### PR TITLE
removing remaining Python2+3 crumbs

### DIFF
--- a/capirca/lib/aclgenerator.py
+++ b/capirca/lib/aclgenerator.py
@@ -21,7 +21,6 @@ import re
 import string
 
 from capirca.lib import policy
-import six
 import hashlib
 
 # generic error class

--- a/capirca/lib/arista_tp.py
+++ b/capirca/lib/arista_tp.py
@@ -21,7 +21,6 @@ import textwrap
 
 from absl import logging
 from capirca.lib import aclgenerator
-import six
 
 #          1         2         3
 # 123456789012345678901234567890123456789

--- a/capirca/lib/cloudarmor.py
+++ b/capirca/lib/cloudarmor.py
@@ -11,8 +11,6 @@ import logging
 
 from capirca.lib import aclgenerator
 
-import six
-
 
 # Generic error class
 class Error(Exception):
@@ -253,6 +251,6 @@ class CloudArmor(aclgenerator.ACLGenerator):
 
     out = '%s\n\n' % (
         json.dumps(self.cloudarmor_policies, indent=2,
-                   separators=(six.ensure_str(','), six.ensure_str(': ')),
+                   separators=(',', ': '),
                    sort_keys=True))
     return out

--- a/capirca/lib/gce.py
+++ b/capirca/lib/gce.py
@@ -30,7 +30,6 @@ from typing import Any, Dict, Iterable, List
 
 from capirca.lib import gcp
 from capirca.lib import nacaddr
-import six
 
 
 class Error(Exception):
@@ -159,7 +158,7 @@ class Term(gcp.Term):
   def __str__(self):
     """Convert term to a string."""
     json.dumps(self.ConvertToDict(), indent=2,
-               separators=(six.ensure_str(','), six.ensure_str(': ')))
+               separators=(',', ': '))
 
   def _validateDirection(self):
     if self.term.direction == 'INGRESS':
@@ -582,8 +581,7 @@ class GCE(gcp.GCP):
 
   def __str__(self):
     out = '%s\n\n' % (json.dumps(self.gce_policies, indent=2,
-                                 separators=(six.ensure_str(','),
-                                             six.ensure_str(': ')),
+                                 separators=(',', ': '),
                                  sort_keys=True))
 
     return out

--- a/capirca/lib/gce_vpc_tf.py
+++ b/capirca/lib/gce_vpc_tf.py
@@ -29,7 +29,6 @@ from typing import Dict, Any
 
 from capirca.lib import gcp
 from capirca.lib import nacaddr
-import six
 
 
 class Error(Exception):
@@ -158,7 +157,7 @@ class Term(gcp.Term):
     json.dumps(
         self.ConvertToDict(priority_index=1),
         indent=2,
-        separators=(six.ensure_str(','), six.ensure_str(': ')))
+        separators=(',', ': '))
 
   def _validateDirection(self):
     if self.term.direction == 'INGRESS':
@@ -610,7 +609,7 @@ class TerraformGCE(gcp.GCP):
         json.dumps(
             self.resource_wrapper,
             indent=2,
-            separators=(six.ensure_str(','), six.ensure_str(': ')),
+            separators=(',', ': '),
             sort_keys=True))
     return out
 

--- a/capirca/lib/gcp.py
+++ b/capirca/lib/gcp.py
@@ -9,8 +9,6 @@ import re
 
 from capirca.lib import aclgenerator
 
-import six
-
 
 class Error(Exception):
   """Generic error class."""
@@ -68,7 +66,7 @@ class GCP(aclgenerator.ACLGenerator):
         json.dumps(
             self.policies,
             indent=2,
-            separators=(six.ensure_str(','), six.ensure_str(': ')),
+            separators=(',', ': '),
             sort_keys=True))
     return out
 

--- a/capirca/lib/juniper.py
+++ b/capirca/lib/juniper.py
@@ -20,7 +20,6 @@ from absl import logging
 from capirca.lib import aclgenerator
 from capirca.lib import nacaddr
 from capirca.lib import summarizer
-import six
 
 
 # generic error class

--- a/capirca/lib/junipermsmpc.py
+++ b/capirca/lib/junipermsmpc.py
@@ -20,7 +20,6 @@ import logging
 from capirca.lib import aclgenerator
 from capirca.lib import juniper
 from capirca.lib import nacaddr
-import six
 
 MAX_IDENTIFIER_LEN = 55  # It is really 63, but leaving room for added chars
 

--- a/capirca/lib/junipersrx.py
+++ b/capirca/lib/junipersrx.py
@@ -25,7 +25,6 @@ import itertools
 from absl import logging
 from capirca.lib import aclgenerator
 from capirca.lib import nacaddr
-import six
 
 
 ICMP_TERM_LIMIT = 8

--- a/capirca/lib/nsxv.py
+++ b/capirca/lib/nsxv.py
@@ -22,7 +22,6 @@ import xml
 from absl import logging
 from capirca.lib import aclgenerator
 from capirca.lib import nacaddr
-import six
 
 
 _ACTION_TABLE = {
@@ -624,7 +623,7 @@ class Nsxv(aclgenerator.ACLGenerator):
     target.append('-->')
 
     for (_, _, _, terms) in self.nsxv_policies:
-      section_name = six.ensure_str(self._FILTER_OPTIONS_DICT['section_name'])
+      section_name = str(self._FILTER_OPTIONS_DICT['section_name'])
       # check section id value
       section_id = self._FILTER_OPTIONS_DICT['section_id']
       if not section_id or section_id == 0:

--- a/capirca/lib/openconfig.py
+++ b/capirca/lib/openconfig.py
@@ -31,7 +31,6 @@ from typing import Dict, Any
 from capirca.lib import aclgenerator
 from capirca.lib import nacaddr
 from collections import defaultdict
-import six
 
 
 class Error(Exception):
@@ -262,8 +261,7 @@ class OpenConfig(aclgenerator.ACLGenerator):
 
   def __str__(self):
     out = '%s\n\n' % (json.dumps(self.oc_policies, indent=2,
-                                 separators=(six.ensure_str(','),
-                                             six.ensure_str(': ')),
+                                 separators=(',', ': '),
                                  sort_keys=True))
 
     return out

--- a/capirca/lib/policy_simple.py
+++ b/capirca/lib/policy_simple.py
@@ -22,7 +22,6 @@ inline comments but preservers line-level comments. Fields expected to have
 """
 
 from absl import logging
-import six
 
 
 class Field:

--- a/capirca/lib/versa.py
+++ b/capirca/lib/versa.py
@@ -25,7 +25,6 @@ import itertools
 from absl import logging
 from capirca.lib import aclgenerator
 from capirca.lib import nacaddr
-#import six
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@
 absl-py
 ply
 PyYAML
-six>=1.12.0
 typing_extensions

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,6 @@ setuptools.setup(
     install_requires=[
         'absl-py',
         'ply',
-        'mock',
-        'six',
         'PyYAML',
     ],
     python_requires='>=3.6',


### PR DESCRIPTION
I see most of `six` usage has already been removed before.