### PR TITLE
workflows: Upgrade actions to latest versions.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Log into registry
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,20 +23,20 @@ jobs:
 
     steps:
     - name: Checkout branch with changes
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: current
     - name: Checkout master branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: master
         ref: master
     - name: Set up Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '14'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup environment variables
@@ -97,12 +97,12 @@ jobs:
           true; done < ./artifacts-diff/files.list
         sed -i '/Diff to HTML by/d' ./artifacts-diff/*
     - name: Upload generated policies
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: capirca_output_${{ matrix.python-version }}_${{ env.wfdt }}
         path: ./artifacts/capirca_output_${{ env.wfdt }}.zip
     - name: Upload policy differences
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: capirca_output_policy_diff
         path: ./artifacts-diff

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,12 +17,12 @@ jobs:
         python-version: [3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ~\AppData\Local\pip\Cache
         key: ${{ runner.os }}-${{ matrix.python-version}}-pip-test-${{ hashFiles('setup.py','requirements.txt','test-requirements.txt') }}
@@ -31,7 +31,7 @@ jobs:
           ${{ runner.os }}-${{ matrix.python-version}}-pip-
           ${{ runner.os }}-${{ matrix.python-version}}-
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.3.3
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -46,7 +46,7 @@ jobs:
         aclgen --output_directory .\output --logtostderr
         powershell Compress-Archive -Force output\* output.zip
     - name: Upload generated policies
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: capirca_output_${{ matrix.python-version }}
         path: ./output.zip


### PR DESCRIPTION
This updates actions to:

* `actions/checkout@v4`
* `actions/setup-python@v5`
* `actions/setup-node@v4`
* `actions/upload-artifact@v4`
* `microsoft/setup-msbuild@v1.3.3`

This is because of the following error which we have been receiving in the CI:

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

This does not attempt to fix the pre-existing build issues caused by typing problems introduced in other commits.